### PR TITLE
Add "set format" command.

### DIFF
--- a/caster/bin/data/ccr/confignavigation.txt
+++ b/caster/bin/data/ccr/confignavigation.txt
@@ -48,9 +48,10 @@ cmd.map = {
 	"Kraken":						R(Key("c-space"), rspec="Kraken", rdescript="Control Space"),
 	     
     # text formatting
+    "set format (<capitalization> <spacing> | <capitalization> | <spacing>) (bow|bowel)":  R(Function(navigation.set_text_format), rdescript="Text Format"), 
     "(<capitalization> <spacing> | <capitalization> | <spacing>) (bow|bowel) <textnv> [brunt]":  R(Function(navigation.master_format_text), rdescript="Text Format"), 
-	"format [<textnv>]":			R(Function(navigation.prior_text_format), rdescript="Last Text Format"),
-	
+    "format [<textnv>]":			R(Function(navigation.prior_text_format), rdescript="Last Text Format"),
+
 	}
 
 cmd.extras = [

--- a/caster/lib/navigation.py
+++ b/caster/lib/navigation.py
@@ -164,7 +164,7 @@ def volume_control(n, volume_mode):
     for i in range(0, int(n)):
         Key("volume" + str(volume_mode)).execute()
     
-def master_format_text(capitalization, spacing, textnv):
+def set_text_format(capitalization, spacing):
     '''
     Commands for capitalization: 
     1 yell - ALLCAPS
@@ -181,10 +181,14 @@ def master_format_text(capitalization, spacing, textnv):
         capitalization = 5
     if spacing == 0 and capitalization == 3:
         spacing = 1
-    Text(get_formatted_text(capitalization, spacing, str(textnv))).execute()
     global CAPITALIZATION, SPACING
     CAPITALIZATION = capitalization
     SPACING = spacing
+    return (capitalization, spacing)
+
+def master_format_text(capitalization, spacing, textnv):
+    (capitalization, spacing) = set_text_format(capitalization, spacing)
+    Text(get_formatted_text(capitalization, spacing, str(textnv))).execute()
 
 def get_formatted_text(capitalization, spacing, t):
     tlen = len(t)


### PR DESCRIPTION
This PR adds an explicit "set format" command. As discussed in the comments on #86, this allows you to separate the selection of a format from the command used to output formatted text, reducing the number of things you need to say for a single utterance.

Usage example: "set format laws spine bow" followed by "format some identifier".