### PR TITLE
Javascript CCR: more consistent code block formatting.

### DIFF
--- a/caster/bin/data/ccr/configjavascript.txt
+++ b/caster/bin/data/ccr/configjavascript.txt
@@ -12,10 +12,10 @@ cmd.map = {
        # Spoken-form    ->    ->    ->     Action object
 		
 		# CCR PROGRAMMING STANDARD
-		"iffae":					R(Text("if (){}")+Key("left, enter:2, up"), rdescript="Javascript: If"),
+		"iffae":					R(Text("if () {}")+Key("left, enter:2, up"), rdescript="Javascript: If"),
 		"shells":					R(Text("else {}")+Key("left, enter:2, up"), rdescript="Javascript: Else"),
 		#
-		"switch":					R(Text("switch(){}")+Key("left, enter:2, up"), rdescript="Javascript: Switch"),
+		"switch":					R(Text("switch() {}")+Key("left, enter:2, up"), rdescript="Javascript: Switch"),
 		"case of":					R(Text("case :")+Key("left"), rdescript="Javascript: Case"),
 		"breaker":					R(Text("break;"), rdescript="Break"),
 		"default":					R(Text("default: "), rdescript="Javascript: Default"),
@@ -37,7 +37,7 @@ cmd.map = {
 		#
 		# (no imports in javascript)
 		# 
-		"function":					R(Text("function NAME(){};")+Key("left:2, enter")
+		"function":					R(Text("function NAME() {};")+Key("left:2, enter")
 									 +SelectiveAction(Key("enter, up"), ["AptanaStudio3.exe"]), 
 									 rdescript="Javascript: Function"),
 		# (no classes in javascript)


### PR DESCRIPTION
A few of the javascript commands were a missing space between () and {} in the output. Neither Visual Studio or Sublime text correct this automatically, which means that some code blocks end up with inconsistent formatting, which I then have to correct manually.