### PR TITLE
Javascript CCR: Add "anon funk" command

### DIFF
--- a/caster/bin/data/ccr/configjavascript.txt
+++ b/caster/bin/data/ccr/configjavascript.txt
@@ -40,6 +40,9 @@ cmd.map = {
 		"function":					R(Text("function NAME(){};")+Key("left:2, enter")
 									 +SelectiveAction(Key("enter, up"), ["AptanaStudio3.exe"]), 
 									 rdescript="Javascript: Function"),
+		"anon funk":				R(Text("function () {}")+Key("left:1, enter")
+									 +SelectiveAction(Key("enter, up"), ["AptanaStudio3.exe"]), 
+									 rdescript="Javascript: Anonymous Function"),
 		# (no classes in javascript)
 		#
 		"add comment":				R(Text("//"), rdescript="Javascript: Add Comment"),


### PR DESCRIPTION
JavaScript makes heavy use of anonymous functions passed as parameters to other functions as callbacks and event handlers. The current "function" command in the JavaScript CCR contains a NAME and a semicolon at the end, both of which then need to be deleted. This PR adds an "anon funk" command, which produces the following output, suitable for embedding in a parameter list:

```
function () {
    |<-- cursor here
}
```