### PR TITLE
Multi-monitor support for grid commands

### DIFF
--- a/_caster.py
+++ b/_caster.py
@@ -84,9 +84,9 @@ class MainRule(MappingRule):
     'quick pass <text> <text2> <text3>':                       R(Function(password.get_simple_password), rdescript="Get Crappy Password"),
     
     # mouse alternatives
-    "legion":                       R(Function(navigation.mouse_alternates, mode="legion"), rdescript="Activate Legion"),
-    "rainbow":                      R(Function(navigation.mouse_alternates, mode="rainbow"), rdescript="Activate Rainbow Grid"),
-    "douglas":                      R(Function(navigation.mouse_alternates, mode="douglas"), rdescript="Activate Douglas Grid"),
+    "legion [<monitor>]":           R(Function(navigation.mouse_alternates, mode="legion"), rdescript="Activate Legion"),
+    "rainbow [<monitor>]":          R(Function(navigation.mouse_alternates, mode="rainbow"), rdescript="Activate Rainbow Grid"),
+    "douglas [<monitor>]":          R(Function(navigation.mouse_alternates, mode="douglas"), rdescript="Activate Douglas Grid"),
     
     # symbol match
     "scan directory":               R(Function(scanner.scan_directory), rdescript="Scan Directory For PITA"),
@@ -119,7 +119,8 @@ class MainRule(MappingRule):
               Choice("volume_mode",
                     {"mute": "mute", "up":"up", "down":"down"
                      }),
-              generate_CCR_choices.__func__()
+              generate_CCR_choices.__func__(),
+              IntegerRefST("monitor", 1, 10)
              ]
     defaults = {"n": 1, "nnv": 1,
                "text": "", "volume_mode": "setsysvolume",

--- a/caster/asynch/mouse/grids.py
+++ b/caster/asynch/mouse/grids.py
@@ -14,6 +14,8 @@ import win32api
 
 import Tkinter as tk
 
+from dragonfly import monitors
+
 try: # Style C -- may be imported into Caster, or externally
     BASE_PATH = os.path.realpath(__file__).split("\\caster")[0].replace("\\", "/")
     if BASE_PATH not in sys.path:
@@ -326,22 +328,30 @@ class DouglasGrid(TkTransparent):
 
     
 def main(argv):
-    help_message = 'grids.py -m <mode>\nr\trainbow grid\nd\tdouglas grid'
+    help_message = 'Usage: grids.py -g <GRID_TYPE> [-m <MONITOR>]\n where <GRID_TYPE> is one of:\n  r\trainbow grid\n  d\tdouglas grid'
     try:
-        opts, args = getopt.getopt(argv, "hm:")
+        opts, args = getopt.getopt(argv, "hg:m:")
     except getopt.GetoptError:
         print help_message
         sys.exit(2)
+    g = None
+    m = 1
     for opt, arg in opts:
         if opt == '-h':
             print help_message
             sys.exit()
-        elif opt == '-m':
+        elif opt == '-g':
             if arg == "r":
-                rg = RainbowGrid()
+                g = RainbowGrid
             elif arg == 'd':
-                dg = DouglasGrid()  # grid_size=Dimensions(400, 300, 0, 0)  
-            
+                g = DouglasGrid  # grid_size=Dimensions(400, 300, 0, 0)
+        elif opt == '-m':
+            m = arg
+    if g == None:
+        raise ValueError("Grid mode not specified.")
+    r = monitors[int(m)-1].rectangle
+    grid_size = Dimensions(int(r.dx), int(r.dy), int(r.x), int(r.y))
+    g(grid_size=grid_size)
 
 if __name__ == '__main__':
     main(sys.argv[1:])

--- a/caster/asynch/mouse/legion.py
+++ b/caster/asynch/mouse/legion.py
@@ -5,6 +5,7 @@ import re
 import sys, os
 import threading
 
+from dragonfly import monitors
 
 
 try: # Style C -- may be imported into Caster, or externally
@@ -162,12 +163,13 @@ class LegionScanner:
 
 
 def main(argv):
-    help_message = 'legion.py -t <tirg> -d <dimensions> -a <autoquit>'
+    help_message = 'legion.py -t <tirg> [-m <monitor>] [-d <dimensions>] [-a <autoquit>]'
     tirg = None
+    monitor = 1
     dimensions = None
     auto_quit = False
     try:
-        opts, args = getopt.getopt(argv, "ht:a:d:", ["tirg=", "dimensions=", "autoquit="])
+        opts, args = getopt.getopt(argv, "ht:a:d:m:", ["tirg=", "dimensions=", "autoquit="])
     except getopt.GetoptError:
         print help_message
         sys.exit(2)
@@ -178,12 +180,17 @@ def main(argv):
                 sys.exit()
             elif opt in ("-t", "--tirg"):
                 tirg = arg
+            elif opt == '-m':
+                monitor = arg
             elif opt in ("-d", "--dimensions"):
                 # wxh+x+y
                 dimensions = Dimensions(*[int(n) for n in arg.split("_")])
             elif opt in ("-a", "--autoquit"):
                 auto_quit = arg in ("1", "t")    
         
+        if dimensions == None:
+            r = monitors[int(monitor)-1].rectangle
+            dimensions = Dimensions(int(r.dx), int(r.dy), int(r.x), int(r.y))
         lg = LegionGrid(grid_size=dimensions, tirg=tirg, auto_quit=auto_quit)
     except Exception:
         utilities.simple_log(True)

--- a/caster/lib/navigation.py
+++ b/caster/lib/navigation.py
@@ -125,7 +125,7 @@ def letters2(big, letter):
     if str(big) != "":
         Key("shift:up").execute()
 
-def mouse_alternates(mode):
+def mouse_alternates(mode, monitor=1):
     if control.nexus().dep.PIL:
         try:
             if mode == "legion":
@@ -135,11 +135,11 @@ def mouse_alternates(mode):
                     ls = LegionScanner()
                     ls.scan()#[500, 500, 1000, 1000]
                     tscan = ls.get_update()
-                    Popen(["pythonw", settings.SETTINGS["paths"]["LEGION_PATH"], "-t", tscan[0]])#, "-d", "500_500_500_500"
+                    Popen(["pythonw", settings.SETTINGS["paths"]["LEGION_PATH"], "-t", tscan[0], "-m", str(monitor)])#, "-d", "500_500_500_500"
             elif mode == "rainbow":
-                Popen(["pythonw", settings.SETTINGS["paths"]["RAINBOW_PATH"], "-m", "r"])
+                Popen(["pythonw", settings.SETTINGS["paths"]["RAINBOW_PATH"], "-g", "r", "-m", str(monitor)])
             elif mode == "douglas":
-                Popen(["pythonw", settings.SETTINGS["paths"]["DOUGLAS_PATH"], "-m", "d"])
+                Popen(["pythonw", settings.SETTINGS["paths"]["DOUGLAS_PATH"], "-g", "d", "-m", str(monitor)])
         except Exception:
             utilities.simple_log(True)
     else:


### PR DESCRIPTION
This PR adds support for multiple monitors when using any of the caster mouse grid commands. Usage is simple: simply append the (optional) monitor number to the grid command you want to use. If you don't specify a monitor number, the grid will display on the primary monitor (monitor 1).

For example, saying "rainbow 2" will display the rainbow grid on monitor 2. To display the rainbow grid on the primary monitor, you can say either "rainbow 1" or simply "rainbow".