### PR TITLE
Allow "pipe (sim | symbol)" for a more phonetically distinct option

### DIFF
--- a/caster/lib/ccr/core/punctuation.py
+++ b/caster/lib/ccr/core/punctuation.py
@@ -28,7 +28,7 @@ class Punctuation(MergeRule):
         "angle":                            R(Key("langle, rangle, left"), rdescript="Angle Brackets"),
         "plus":                             R(Text("+"), rdescript="Plus Sign"),
         "minus":                            R(Text("-"), rdescript="Dash"),
-        "pipe sim":                         R(Text("|"), rdescript="Pipe Symbol"),
+        "pipe (sim | symbol)":              R(Text("|"), rdescript="Pipe Symbol"),
         'ace [<npunc>]':                    R(Key("space"), rdescript="Space") * Repeat(extra="npunc"),
         "clamor":                           R(Text("!"), rdescript="Exclamation Mark"),
         "deckle":                           R(Text(":"), rdescript="Colon"),


### PR DESCRIPTION
More often than not, DNS hears "type seven" when I say "pipe sim". "Pipe symbol" is more phonetically distinct, and easy enough to remember and say, so I thought it might be good to give users that option out of the box. Feel free to reject the PR if you think this falls into the category of things I should address via filter functions.