### PR TITLE
Mouse improvements, app grammar updates, next/prior window

### DIFF
--- a/caster/apps/explorer.py
+++ b/caster/apps/explorer.py
@@ -1,0 +1,31 @@
+from dragonfly import (Grammar, AppContext, MappingRule,
+                       Dictation, IntegerRef,
+                       Key, Text, Repeat, Pause)
+
+from caster.lib import settings
+from caster.lib.dfplus.additions import IntegerRefST
+from caster.lib.dfplus.state.short import R
+
+
+class CommandRule(MappingRule):
+
+    mapping = {
+        "address bar":                       R(Key("a-d"), rdescript="Explorer: Address Bar"),
+        "new folder":                        R(Key("cs-n"), rdescript="Explorer: New Folder"),
+        "new file":                          R(Key("a-f, w, t"), rdescript="Explorer: New File"),
+        "(show | file | folder) properties": R(Key("a-enter"), rdescript="Explorer: Properties Dialog"),
+        }
+    extras = [
+              Dictation("text"),
+              IntegerRefST("n", 1, 1000),
+              
+             ]
+    defaults = {"n": 1}
+
+#---------------------------------------------------------------------------
+
+context = AppContext(executable="explorer")
+grammar = Grammar("Windows Explorer", context=context)
+grammar.add_rule(CommandRule(name="explorer"))
+if settings.SETTINGS["apps"]["explorer"]:
+    grammar.load()

--- a/caster/apps/visualstudio.py
+++ b/caster/apps/visualstudio.py
@@ -31,6 +31,9 @@ class CommandRule(MappingRule):
         "(set | toggle) bookmark":      R(Key("c-k, c-k"), rdescript="Visual Studio: Toggle Bookmark"),
         "next bookmark":                R(Key("c-k, c-n"), rdescript="Visual Studio: Next Bookmark"),
         "prior bookmark":               R(Key("c-k, c-p"), rdescript="Visual Studio: Previous Bookmark"),
+        "collapse to definitions":      R(Key("c-m, c-o"), rdescript="Visual Studio: Collapse To Definitions"),
+        "toggle [section] outlining":   R(Key("c-m, c-m"), rdescript="Visual Studio: Toggle Section Outlining"),
+        "toggle all outlining":         R(Key("c-m, c-l"), rdescript="Visual Studio: Toggle All Outlining"),
         
         "[toggle] breakpoint":          R(Key("f9"), rdescript="Visual Studio: Breakpoint"),
         "step over [<n>]":              R(Key("f10/50") * Repeat(extra="n"), rdescript="Visual Studio: Step Over"),
@@ -41,6 +44,7 @@ class CommandRule(MappingRule):
         "get latest [version]":         R(Key("a-f, r, l"), rdescript="Visual Studio: Get Latest"),
         "(show | view) history":        R(Key("a-f, r, h"), rdescript="Visual Studio: Show History"),
         "compare (files | versions)":   R(Key("a-f, r, h"), rdescript="Visual Studio: Compare..."),
+        "undo (checkout | pending changes)": R(Key("a-f, r, u"), rdescript="Visual Studio: Undo Pending Changes"),
         
         "[open] [go to] work item":     R(Key("a-m, g"), rdescript="Visual Studio: Open Work Item"),
         "[add] [new] linked work item": R(Key("sa-l"), rdescript="Visual Studio: New Linked Work Item"),

--- a/caster/lib/ccr/core/nav.py
+++ b/caster/lib/ccr/core/nav.py
@@ -39,6 +39,7 @@ class NavigationNon(MappingRule):
         '(kick double|double kick)':        R(Function(navigation.kick) * Repeat(2), rdescript="Mouse: Double Click"),
         "shift right click":                R(Key("shift:down") + Mouse("right") + Key("shift:up"), rdescript="Mouse: Shift + Right Click"),
         "curse <direction> [<direction2>] [<nnavi500>] [<dokick>]": R(Function(navigation.curse), rdescript="Curse"),
+        "scree <direction> [<nnavi500>]":   R(Function(navigation.wheel_scroll), rdescript="Wheel Scroll"),
       
         "colic":                            R(Key("control:down") + Mouse("left") + Key("control:up"), rdescript="Mouse: Ctrl + Left Click"),
         "garb [<nnavi500>]":                R(Mouse("left")+Mouse("left")+Key("c-c")+Function(navigation.clipboard_to_file), rdescript="Highlight @ Mouse + Copy"),
@@ -59,6 +60,7 @@ class NavigationNon(MappingRule):
         "window (right | ross) [<n>]":      R(Key("w-right"), rdescript="Window Right") * Repeat(extra="n"),
         "monitor (left | lease) [<n>]":     R(Key("sw-left"), rdescript="Monitor Left") * Repeat(extra="n"),
         "monitor (right | ross) [<n>]":     R(Key("sw-right"), rdescript="Monitor Right") * Repeat(extra="n"),
+        "(next | prior) window":            R(Key("ca-tab, enter"), rdescript="Next Window"),
         "switch (window | windows)":        R(Key("ca-tab"), rdescript="Switch Window") * Repeat(extra="n"),
         
         "next tab [<n>]":                   R(Key("c-pgdown"), rdescript="Next Tab") * Repeat(extra="n"),

--- a/caster/lib/navigation.py
+++ b/caster/lib/navigation.py
@@ -290,11 +290,13 @@ def kill_grids_and_wait():
 
 def kick():
     kill_grids_and_wait()
-    Playback([(["mouse", "left", "click"], 0.0)]).execute()
+    windll.user32.mouse_event(0x00000002, 0, 0, 0, 0)
+    windll.user32.mouse_event(0x00000004, 0, 0, 0, 0)
 
 def kick_right():
     kill_grids_and_wait()
-    Playback([(["mouse", "right", "click"], 0.0)]).execute()
+    windll.user32.mouse_event(0x00000008, 0, 0, 0, 0)
+    windll.user32.mouse_event(0x00000010, 0, 0, 0, 0)
 
 def kick_middle():
     kill_grids_and_wait()

--- a/caster/lib/navigation.py
+++ b/caster/lib/navigation.py
@@ -303,6 +303,13 @@ def kick_middle():
     windll.user32.mouse_event(0x00000020, 0, 0, 0, 0)
     windll.user32.mouse_event(0x00000040, 0, 0, 0, 0)
 
+def wheel_scroll(direction, nnavi500):
+    amount = 120
+    if direction != "up":
+        amount = amount * -1;
+    for i in xrange(1, abs(nnavi500)+1):
+        windll.user32.mouse_event(0x00000800, 0, 0, amount, 0)
+        time.sleep(0.1)
 
     
 def curse(direction, direction2, nnavi500, dokick):

--- a/caster/lib/settings.py
+++ b/caster/lib/settings.py
@@ -152,6 +152,7 @@ def init_default_values():
                        ("dragon", True),
                        ("eclipse", True),
                        ("emacs", True),
+                       ("explorer", True),
                        ("firefox", True),
                        ("foxitreader", True),
                        ("gitbash", True),


### PR DESCRIPTION
* Added Windows Explorer grammar and updated Visual Studio grammar.

* Replaced the use of the Playback action in the right and left click commands with direct calls to the underlying user32 api calls to improve performance. The existing commands rely on the Dragon engine to perform mouse clicks, and this often causes a lag of a few hundred milliseconds for me. Sometimes it would also cause double-click to fail altogether.

* Added "next/prior window" command. "Next window" and "prior window" both do the same thing and are simply a shortcut for saying "switch window" followed by "shock". Convenient for repeatedly switching back and forth between two windows.

* Added mouse wheel scrolling, with the following caveat. For some windows, scrolling works regardless of whether the mouse pointer is over the scrollable area. These will simply scroll the text control or other scrollable area that has the focus. For others, in particular most IDEs that I've tried, only work when the mouse pointer is over the scrollable area that you want to scroll. I have ideas for working around this limitation in some apps, but I figured in the meantime, partially working mouse wheel support is better than none at all.