### PR TITLE
Update mouse documentation

### DIFF
--- a/caster/doc/readthedocs/Mouse.MD
+++ b/caster/doc/readthedocs/Mouse.MD
@@ -1,16 +1,56 @@
 # Alternate Mouse Modes
-
 Demonstration [here](https://youtu.be/UISjQBMmQ-I).
 
-## Rainbow
-Creates a grid on the screen that is colored. You can select a square by calling out the color followed by the number of the tile. For example, "red 86". The colors loop when filling the screen, so you can select the second row of colors by saying "two red 86".
+## Basic mouse commands
 
-## Douglas
-Creates a grid on the screen and you can select a square by calling out the horizontal number, then the word "by", then the vertical number. For example, "5 by 50".  
+### Clicking
+- Left click: *kick*
+- Right click: *psychic* 
 
-## Legion
-Finds text on the screen and gives each a number which you can call out.
+### Moving 
+- Move around: *mouse* *<direction>* *<distance_in_pixel>*  
+    *<direction>* can be *up*, *down*, *right* and *left*. 
 
-## Clicking
-- "kick" produces a left click
-- "psychic" produces a right click
+## Advanced mouse commands
+
+### Mousegrid
+**Description**:  
+- Approach the desired position by recursively selecting tiles on the screen. Provided by Dragon Naturally Speaking. 
+
+**Usage**:  
+- Evoke: *mousegrid*
+- Select tile: *<tile_number>*  
+  *<tile_number>* can be anything from 1 to 9.  
+
+### Douglas
+**Description**:  
+- Creates a grid on the screen with horizontal and vertical numbers at the borders. Squares are directly selectable by calling out the respective numbers.
+
+**Usage**:  
+- Evoke: *douglas*
+- Select square: *<horizontal_number>* *by* *<vertical_number>*  
+
+**Example**:  
+- *5 by 20*
+
+### Rainbow
+**Description**:  
+- Creates a colored grid on the screen. Squares are directly selectable by calling out the respective color and number.
+
+**Usage**:  
+- Evoke: *rainbow*
+- Select square: *[<number_of_color_palette]* *<color>* *<number>*  
+    *<number_of_color_palette>* refers to the fact that colors loop when filling the screen.  
+    *<color>* can be replaced by the following colors: *red*, *orange*, *yellow*, *green*, *blue*, *purple*.
+
+**Example**:  
+- *red 86*: - References the according square within the first color palette.
+- *two red 86*  - References the according square within the second color palette.
+
+### Legion
+**Description**:  
+- Finds text on the screen and gives each a number which you can call out.
+
+**Usage**:  
+- Evoke: *legion*
+- Select text area: *<number>*


### PR DESCRIPTION
I worked through the [Alternate Mouse Movement Modes video](https://www.youtube.com/watch?v=UISjQBMmQ-I) and noticed that the [documentation](http://caster.readthedocs.io/en/latest/caster/doc/readthedocs/Mouse/) is missing the colors for the rainbow command, so I thought it would be nice adding them. I also changed the structure of the documentation page - please feel free to reject this pull request if you don't like it (e.g. the documentation got longer). The mouse commands were missing too, however, _curse up left 30_ did not work for me. To make it work I had to replace _curse_ by _mouse_ and use only one direction: _mouse up 30_. If this is an issue only I have, please feel free to edit this or let me know.