### PR TITLE
Text formatting usability improvements

### DIFF
--- a/caster/lib/ccr/core/nav.py
+++ b/caster/lib/ccr/core/nav.py
@@ -143,7 +143,9 @@ class Navigation(MergeRule):
     "Kraken":                       R(Key("c-space"), rspec="Kraken", rdescript="Control Space"),
          
     # text formatting
-    "set format (<capitalization> <spacing> | <capitalization> | <spacing>) (bow|bowel)":  R(Function(textformat.set_text_format), rdescript="Set Text Format"), 
+    "set format (<capitalization> <spacing> | <capitalization> | <spacing>) (bow|bowel)":  R(Function(textformat.set_text_format), rdescript="Set Text Format"),
+    "clear caster formatting":      R(Function(textformat.clear_text_format), rdescript="Clear Caster Formatting"),
+    "peek format":                  R(Function(textformat.peek_text_format), rdescript="Peek Format"),
     "(<capitalization> <spacing> | <capitalization> | <spacing>) (bow|bowel) <textnv> [brunt]":  R(Function(textformat.master_format_text), rdescript="Text Format"), 
     "format <textnv>":              R(Function(textformat.prior_text_format), rdescript="Last Text Format"),
     

--- a/caster/lib/textformat.py
+++ b/caster/lib/textformat.py
@@ -1,4 +1,5 @@
 import time
+import sys
 
 from dragonfly.actions.action_key import Key
 from dragonfly.actions.action_text import Text
@@ -7,7 +8,7 @@ from caster.lib import settings
 
 _CAPITALIZATION, _SPACING = 0, 0
 
-def set_text_format(capitalization, spacing):
+def normalize_text_format(capitalization, spacing):
     '''
     Commands for capitalization: 
     1 yell - ALLCAPS
@@ -24,13 +25,47 @@ def set_text_format(capitalization, spacing):
         capitalization = 5
     if spacing == 0 and capitalization == 3: 
         spacing = 1
+    return capitalization, spacing
+
+def set_text_format(capitalization, spacing):
+    capitalization, spacing = normalize_text_format(capitalization, spacing)
     global _CAPITALIZATION, _SPACING
     _CAPITALIZATION = capitalization
     _SPACING = spacing
-    return capitalization, spacing
+    print("Text formatting: %s" % get_text_format_description(_CAPITALIZATION, _SPACING))
+
+def clear_text_format():
+    global _CAPITALIZATION, _SPACING
+    _CAPITALIZATION = 0
+    _SPACING = 0
+
+def peek_text_format():
+    global _CAPITALIZATION, _SPACING
+    print("Text formatting: %s" % get_text_format_description(_CAPITALIZATION, _SPACING))
+
+def get_text_format_description(capitalization, spacing):
+    caps = {
+        0: "<none>",
+        1: "yell",
+        2: "tie",
+        3: "gerrish",
+        4: "sing",
+        5: "laws"
+        }
+    spaces = {
+        0: "<none>",
+        1: "gum",
+        2: "spine",
+        3: "snake"
+        }
+    if capitalization == 0 and spacing == 0:
+        return "<none>"
+    else:
+        text = get_formatted_text(capitalization, spacing, str("this is a test"))
+        return "%s %s (%s)" % (caps[capitalization], spaces[spacing], text)
 
 def master_format_text(capitalization, spacing, textnv):
-    capitalization, spacing = set_text_format(capitalization, spacing)
+    capitalization, spacing = normalize_text_format(capitalization, spacing)
     Text(get_formatted_text(capitalization, spacing, str(textnv))).execute()    
 
 def get_formatted_text(capitalization, spacing, t):


### PR DESCRIPTION
- Remove implicit "set format" (see #158). The "set format" command also now prints the new text format to the NatLink window (see "peek format" command below)
- Added "clear caster formatting" command. I find that sometimes it's convenient to be able to output text without any added formatting into a program that's not supported by Dragon (eg comments in code files).
- Added "peek format" command, which will print the current text format to the NatLink window. For example, it will print something like `Text formatting: laws spine (this-is-a-test)`.