### PR TITLE
Fix "no handlers could be found for logger" error messages

### DIFF
--- a/_caster.py
+++ b/_caster.py
@@ -4,6 +4,9 @@ main Caster module
 Created on Jun 29, 2014
 '''
 
+import logging
+logging.basicConfig()
+
 import time
 from dragonfly import (Key, Function, Grammar, Playback, Dictation, Choice, Pause)
 from caster.lib.ccr.standard import SymbolSpecs


### PR DESCRIPTION
Minor update to fix the occasional "no handlers could be found for logger" messages that occasionally appear in the NatLink status window. Now if an error bubbles up to one of the Dragonfly Action classes, it should print the exception and stack trace information, which we can use for debugging.