### PR TITLE
context fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ test.py
 log.txt
 complexity_report*
 *.log
+*.*\#
+*.*~
+
 
 # Ignore Natlink
 /core/

--- a/caster/apps/gitbash.py
+++ b/caster/apps/gitbash.py
@@ -89,9 +89,12 @@ class GitBashRule(MergeRule):
 
 #---------------------------------------------------------------------------
 
-context = AppContext(executable="sh")
-context2 = AppContext(executable="cmd")
-grammar = Grammar("MINGW32", context=(context | context2))
+context = AppContext(executable="\\sh.exe")
+context2 = AppContext(executable="\\bash.exe")
+context3 = AppContext(executable="\\cmd.exe")
+context4 = AppContext(executable="\\mintty.exe")
+
+grammar = Grammar("MINGW32", context=(context | context2 | context3 | context4))
 
 if settings.SETTINGS["apps"]["gitbash"]:
     if settings.SETTINGS["miscellaneous"]["rdp_mode"]:


### PR DESCRIPTION
I added the terminal I use to access git to the list of app contexts where the git rules are active. I also tracked down an issue I was just having over the weekend where the context was getting activated when I tried to connect to Wi-Fi through the system tray. The new start menu in Windows 10 is provided through `ShellExperienceHost.exe`, which was causing a false match against `sh`.

I also added the cruft that Emacs likes to leave everywhere to `.gitignore`. If you would like me to resubmit it separately, please let me know.