### PR TITLE
History fixes

### DIFF
--- a/caster/lib/ccr/recording/history.py
+++ b/caster/lib/ccr/recording/history.py
@@ -80,7 +80,6 @@ class HistoryRule(SelfModifyingRule):
 			# Further, I changed the delay from 0.0 to 1.0. The delay of 0.0 generally did not work for me. We may want to consider
 			# exposing this as a configurable setting.
             mapping[ascii_str] = R(Playback([(sequence, 1.0) for sequence in sequences]), rdescript="Recorded Macro: " + ascii_str)
-        print("14.")
         mapping["record from history"] = R(Function(self.record_from_history), rdescript="Record From History")
         mapping["delete recorded macros"] = R(Function(self.delete_recorded_macros), rdescript="Delete Recorded Macros")
         # reload with new mapping

--- a/caster/lib/ccr/recording/history.py
+++ b/caster/lib/ccr/recording/history.py
@@ -76,10 +76,9 @@ class HistoryRule(SelfModifyingRule):
             # Create a copy of the string without Unicode characters.
             ascii_str = str(spec)
             sequences = recorded_macros[spec]
+            delay = settings.SETTINGS["miscellaneous"]["history_playback_delay_secs"]
             # It appears that the associative string (ascii_str) must be ascii, but the sequences within Playback must be Unicode.
-			# Further, I changed the delay from 0.0 to 1.0. The delay of 0.0 generally did not work for me. We may want to consider
-			# exposing this as a configurable setting.
-            mapping[ascii_str] = R(Playback([(sequence, 1.0) for sequence in sequences]), rdescript="Recorded Macro: " + ascii_str)
+            mapping[ascii_str] = R(Playback([(sequence, delay) for sequence in sequences]), rdescript="Recorded Macro: " + ascii_str)
         mapping["record from history"] = R(Function(self.record_from_history), rdescript="Record From History")
         mapping["delete recorded macros"] = R(Function(self.delete_recorded_macros), rdescript="Delete Recorded Macros")
         # reload with new mapping

--- a/caster/lib/ccr/recording/history.py
+++ b/caster/lib/ccr/recording/history.py
@@ -46,7 +46,8 @@ class HistoryRule(SelfModifyingRule):
         
         word_sequences = [] # word_sequences is a list of lists of strings
         for i in data["selected_indices"]:
-            single_sequence = self.nexus.preserved[i]
+            # Convert from a tuple to a list because we may need to modify it.
+            single_sequence = list(self.nexus.preserved[i])
             # clean the results
             for k in range(0,len(single_sequence)):
                 if "\\" in single_sequence[k]:
@@ -72,8 +73,14 @@ class HistoryRule(SelfModifyingRule):
             utilities.save_json_file(recorded_macros, settings.SETTINGS["paths"]["RECORDED_MACROS_PATH"])
         mapping = {}
         for spec in recorded_macros:
+            # Create a copy of the string without Unicode characters.
+            ascii_str = str(spec)
             sequences = recorded_macros[spec]
-            mapping[spec] = R(Playback([(sequence, 0.0) for sequence in sequences])*Repeat(extra="n"), rdescript="Recorded Macro: "+spec)
+            # It appears that the associative string (ascii_str) must be ascii, but the sequences within Playback must be Unicode.
+			# Further, I changed the delay from 0.0 to 1.0. The delay of 0.0 generally did not work for me. We may want to consider
+			# exposing this as a configurable setting.
+            mapping[ascii_str] = R(Playback([(sequence, 1.0) for sequence in sequences]), rdescript="Recorded Macro: " + ascii_str)
+        print("14.")
         mapping["record from history"] = R(Function(self.record_from_history), rdescript="Record From History")
         mapping["delete recorded macros"] = R(Function(self.delete_recorded_macros), rdescript="Delete Recorded Macros")
         # reload with new mapping

--- a/caster/lib/settings.py
+++ b/caster/lib/settings.py
@@ -212,7 +212,8 @@ def init_default_values():
                        ("rdp_mode", False),
                        ("integer_remap_opt_in", False), 
                        ("integer_remap_crash_fix", False),
-                       ("print_rdescripts", False)
+                       ("print_rdescripts", False),
+                       ("history_playback_delay_secs", 1.0)
                        ])
     
     # pronunciations section


### PR DESCRIPTION
1. Say I had created a sequence of commands using the phonetic alphabet (e.g. "Press control Charlie"). The sequence failed to save  because of the slash  character associated with the phonetic pronunciation. This was because the code was attempting to remove the slashes. However, the type was an immutable tuple and could not be assigned to. I fixed it by changing it to a list.

2. Once created, the sequence did not load properly because the name was read in as Unicode characters from the JSON file. A downstream dependency was not expecting Unicode and failed. Fixed by immediately converting it to an ASCII string when read.