### PR TITLE
Change get_name to get_pronunciation to clarify what's being used.

### DIFF
--- a/caster/apps/eclipse.py
+++ b/caster/apps/eclipse.py
@@ -170,7 +170,7 @@ class EclipseRule(MergeRule):
 class EclipseCCR(MergeRule):
     pronunciation = "eclipse jump"
     
-    mwith = [Navigation().get_name()]
+    mwith = [Navigation().get_pronunciation()]
     
     mapping = {
             #Line Ops

--- a/caster/apps/flashdevelop.py
+++ b/caster/apps/flashdevelop.py
@@ -57,7 +57,7 @@ class FlashDevelopRule(MergeRule):
 
 class FlashDevelopCCR(MergeRule):
     pronunciation = "flash develop test"
-    mwith = [Navigation().get_name()]
+    mwith = [Navigation().get_pronunciation()]
     
     mapping = {
             "[go to] line <n>":                         R(Key("c-g") + Pause("50") + Text("%(n)d") + Key("enter"), 

--- a/caster/doc/readthedocs/examples/rules/Caster Rules.MD
+++ b/caster/doc/readthedocs/examples/rules/Caster Rules.MD
@@ -341,9 +341,9 @@ def update_python(rule):
 
 def replace_python_else_action(mp):
     if mp.time == MergeInf.RUN and mp.type == MergeInf.GLOBAL:
-        if mp.rule1 is not None and mp.rule1.get_name() == "Python":
+        if mp.rule1 is not None and mp.rule1.get_pronunciation() == "Python":
             update_python(mp.rule1)
-        if mp.rule2.get_name() == "Python":
+        if mp.rule2.get_pronunciation() == "Python":
             update_python(mp.rule2)
         
 control.nexus().merger.add_filter(replace_python_else_action)
@@ -359,7 +359,7 @@ from caster.lib.dfplus.merge.mergepair import MergeInf
 from caster.lib.dfplus.state.short import R
 
 def add_is_to_python(rule):
-    if rule.get_name() == "Python":
+    if rule.get_pronunciation() == "Python":
         rule.mapping_actual()["identity is"] = R(Text(" is "), rdescript="Python: Is")
 
 def add_is_to_python_filter(mp):

--- a/caster/lib/dfplus/hint/hintnode.py
+++ b/caster/lib/dfplus/hint/hintnode.py
@@ -91,7 +91,7 @@ class NodeRule(SelfModifyingRule):
         
         self.refresh(node, first, is_reset)
     
-    def get_name(self):
+    def get_pronunciation(self):
         return self.master_node.spec
     
     def refresh(self, *args):

--- a/caster/lib/dfplus/merge/ccrmerger.py
+++ b/caster/lib/dfplus/merge/ccrmerger.py
@@ -100,14 +100,14 @@ class CCRMerger(object):
     
     '''setup: adding rules and filters'''
     def add_global_rule(self, rule):
-        assert rule.get_context() is None, "global rules may not have contexts, "+rule.get_name()+" has a context: "+str(rule.get_context())
+        assert rule.get_context() is None, "global rules may not have contexts, "+rule.get_pronunciation()+" has a context: "+str(rule.get_context())
         assert isinstance(rule, MergeRule) and not hasattr(rule, "set_merger"), \
             "only MergeRules may be added as global rules; use add_selfmodrule() or add_app_rule()"
         self._add_to(rule, self._global_rules)
     def add_app_rule(self, rule, context=None):
         if context is not None and rule.get_context() is None: rule.set_context(context)
-        assert rule.get_context() is not None, "app rules must have contexts, "+rule.get_name()+" has no context"
-        assert rule.get_merge_with() is not None, "app rules must define mwith, "+rule.get_name()+" has no mwith"
+        assert rule.get_context() is not None, "app rules must have contexts, "+rule.get_pronunciation()+" has no context"
+        assert rule.get_merge_with() is not None, "app rules must define mwith, "+rule.get_pronunciation()+" has no mwith"
         self._add_to(rule, self._app_rules)
     def add_selfmodrule(self, rule):
         assert hasattr(rule, "set_merger"), "only SelfModifyingRules may be added by add_selfmodrule()"
@@ -118,15 +118,15 @@ class CCRMerger(object):
         if not filter in self._filters:
             self._filters.append(filter)
     def _add_to(self, rule, group):
-        if rule.get_name() in \
+        if rule.get_pronunciation() in \
         self.global_rule_names()+\
         self.app_rule_names()+\
         self.selfmod_rule_names():
-            raise Exception("Rule Naming Conflict: "+rule.get_name())
+            raise Exception("Rule Naming Conflict: "+rule.get_pronunciation())
         if isinstance(rule, MergeRule):
             for name in group.keys(): 
                 group[name].compatibility_check(rule) # calculate compatibility for uncombined rules at boot time
-            group[rule.get_name()] = rule
+            group[rule.get_pronunciation()] = rule
     
     '''getters'''
     def global_rule_names(self):
@@ -293,10 +293,10 @@ class CCRMerger(object):
         '''save if necessary'''
         if time in [MergeInf.RUN, MergeInf.SELFMOD] and save:
             # everything in base composite is active, everything in selfmod is active, update the config as such
-            active_global_names = [rule.get_name() for rule in active_global]
+            active_global_names = [rule.get_pronunciation() for rule in active_global]
             for rule_name in self._global_rules:
                 self._config[CCRMerger._GLOBAL][rule_name] = rule_name in active_global_names
-            active_selfmod_names = [name3 for name3 in self._config[CCRMerger._SELFMOD] if self._config[CCRMerger._SELFMOD][name3]]#[rule.get_name() for rule in selfmod]
+            active_selfmod_names = [name3 for name3 in self._config[CCRMerger._SELFMOD] if self._config[CCRMerger._SELFMOD][name3]]#[rule.get_pronunciation() for rule in selfmod]
             for rule_name in self._self_modifying_rules:
                 self._config[CCRMerger._SELFMOD][rule_name] = rule_name in active_selfmod_names
             self.save_config()

--- a/caster/lib/dfplus/merge/mergerule.py
+++ b/caster/lib/dfplus/merge/mergerule.py
@@ -46,7 +46,7 @@ class MergeRule(MappingRule):
     '''app MergeRules MUST define `mwith` in order to
     define what else they can merge with -- this is an
     optimization to prevent pointlessly large global
-    CCR copies; mwith is a list of get_name()s'''
+    CCR copies; mwith is a list of get_pronunciation()s'''
     mwith = None
     
     def __init__(self, name=None, mapping=None, extras=None, defaults=None,
@@ -94,12 +94,12 @@ class MergeRule(MappingRule):
         defaults = self.defaults_copy()
         defaults.update(other.defaults_copy())
         context = self._mcontext if self._mcontext is not None else other.get_context() # one of these should always be None; contexts don't mix here
-        return MergeRule("Merged"+MergeRule.get_merge_name()+self.get_name()[0]+other.get_name()[0], 
+        return MergeRule("Merged"+MergeRule.get_merge_name()+self.get_pronunciation()[0]+other.get_pronunciation()[0], 
                          mapping, extras, defaults, self._exported and other._exported, # no ID
                          composite=self.composite.union(other.composite), mcontext=context)
                 
-    def get_name(self):
-        return self.name if self.pronunciation is None else self.pronunciation
+    def get_pronunciation(self):
+        return self.pronunciation if self.pronunciation is not None else self.name
     def copy(self):
         return MergeRule(self.name, self._mapping.copy(), self._extras.values(), self._defaults.copy(), 
                          self._exported, self.ID, self.composite, self.compatible, self._mcontext, self._mwith)

--- a/caster/lib/tests/complexity.py
+++ b/caster/lib/tests/complexity.py
@@ -144,7 +144,7 @@ def test(specs, choices, ccr_max):
     '''activate everything except the heavy rule'''
     merger_ccr_activator = merger.global_rule_changer()
     for rule in core_and_python():
-        merger_ccr_activator(rule.get_name(), True, False)
+        merger_ccr_activator(rule.get_pronunciation(), True, False)
     print("..")
     merger.selfmod_rule_changer()("css", True, False)
     print("...")

--- a/caster/lib/tests/unit/merger.py
+++ b/caster/lib/tests/unit/merger.py
@@ -16,7 +16,7 @@ from caster.lib.tests.unit.state import TestNexus
 def demo_filter(_):
     ''' delete conflicting specs out of the base rule '''
     if _.type == MergeInf.GLOBAL and _.time != MergeInf.BOOT \
-    and _.rule1 is not None and _.rule2.get_name()=="Bash":
+    and _.rule1 is not None and _.rule2.get_pronunciation()=="Bash":
         for spec in _.rule1.mapping_actual().keys():
             if spec in _.rule2.mapping_actual().keys():
                 del _.rule1.mapping_actual()[spec]

--- a/caster/user/filters/examples/modkeysup.py
+++ b/caster/user/filters/examples/modkeysup.py
@@ -13,7 +13,7 @@ def add_modkeys(rule):
     release = R(Key("shift:up, ctrl:up, alt:up"), rdescript = "Mod Keys Up")
     
     if not hasattr(rule, "marked") and\
-    rule.get_name()[0:6] != "Merged": # don't augment merged rules-- they'd get it twice
+    rule.get_pronunciation()[0:6] != "Merged": # don't augment merged rules-- they'd get it twice
         for spec in rule.mapping_actual().keys():
             rule.mapping_actual()[spec] = release + rule.mapping_actual()[spec] + release
         rule.marked = True

--- a/caster/user/filters/examples/scen4.py
+++ b/caster/user/filters/examples/scen4.py
@@ -50,15 +50,15 @@ def scenario_3(mp):
     if mp.time == MergeInf.RUN and mp.type == MergeInf.GLOBAL:
         # Inf.RUN means any time except boot or SelfModifyingRule updates
         # Ing.GLOBAL means during global rule de/activation
-        if mp.rule1 is not None and mp.rule1.get_name() == "Python":
+        if mp.rule1 is not None and mp.rule1.get_pronunciation() == "Python":
             update_python(mp.rule1)
-        if mp.rule2.get_name() == "Python":
+        if mp.rule2.get_pronunciation() == "Python":
             update_python(mp.rule2)
         
 # control.nexus().merger.add_filter(scenario_3)
 
 def add_is_to_python(rule):
-    if rule.get_name() == "Python":
+    if rule.get_pronunciation() == "Python":
         rule.mapping_actual()["identity is"] = R(Text(" is "), rdescript="Python: Is")
 
 def scenario_4(mp):


### PR DESCRIPTION
The current use of get_name preferentially returns the pronunciation instead of the name of a rule.
This change updates `get_name` to be `get_pronunciation`  so the method name is more in line with the underlying logic.


Original:
```python
def get_name(self):
    return self.name if self.pronunciation is None else self.pronunciation
```
Updated:
```python
def get_pronunciation(self):
    return self.pronunciation if self.pronunciation is not None else self.name
```