### PR TITLE
Rework and clean up setting.py

### DIFF
--- a/caster/lib/settings.py
+++ b/caster/lib/settings.py
@@ -1,10 +1,10 @@
 import json
 import os
 import sys
+import collections
 
-SETTINGS = None
-BAD_LOAD = False
-INISETPATH = os.path.realpath(__file__).split("lib")[0]+"bin\\data\\settings.json"
+SETTINGS = {}
+_SETTINGS_PATH = os.path.realpath(__file__).split("lib")[0]+"bin\\data\\settings.json"
 BASE_PATH = os.path.realpath(__file__).split("\\lib")[0].replace("\\", "/")
 
 # title
@@ -31,11 +31,126 @@ HMC_SEPARATOR = "[hmc]"
 
 WSR = False
 
+def _find_natspeak():
+    '''Tries to find the natspeak engine.'''
+    possible_locations = [
+        "C:/Program Files (x86)/Nuance/NaturallySpeaking14/Program/natspeak.exe",
+        "C:/Program Files (x86)/Nuance/NaturallySpeaking13/Program/natspeak.exe",
+        "C:/Program Files (x86)/Nuance/NaturallySpeaking12/Program/natspeak.exe",
+    ]
+    for location in possible_locations:
+        if os.path.isfile(location):
+            return location
+    print "Cannot find default dragon engine path"
+    return ""
+
+# The defaults for every setting. Could be moved out into its own file. 
+_DEFAULT_SETTINGS = {
+    "paths": {
+        "BASE_PATH": BASE_PATH,
+
+        # DATA
+        "ALIAS_PATH": BASE_PATH + "/bin/data/aliases.json.",
+        "CCR_CONFIG_PATH": BASE_PATH + "/bin/data/ccr.json",
+        "DLL_PATH": BASE_PATH + "/lib/dll/",
+        "FILTER_DEFS_PATH": BASE_PATH + "/user/words.txt",
+        "LOG_PATH": BASE_PATH + "/bin/data/log.txt",
+        "RECORDED_MACROS_PATH": BASE_PATH + "/bin/data/recorded_macros.json",
+        "SAVED_CLIPBOARD_PATH": BASE_PATH + "/bin/data/clipboard.json",
+        "SIKULI_SCRIPTS_FOLDER_PATH": BASE_PATH + "/asynch/sikuli/scripts",
+
+        # REMOTE_DEBUGGER_PATH is the folder in which pydevd.py can be found
+        "REMOTE_DEBUGGER_PATH": "",
+
+        # EXECUTABLES
+        "DEFAULT_BROWSER_PATH": "C:/Program Files (x86)/Mozilla Firefox/firefox.exe",
+        "DOUGLAS_PATH": BASE_PATH + "/asynch/mouse/grids.py",
+        "ENGINE_PATH": _find_natspeak(),
+        "HOMUNCULUS_PATH": BASE_PATH + "/asynch/hmc/h_launch.py",
+        "LEGION_PATH": BASE_PATH + "/asynch/mouse/legion.py",
+        "MEDIA_PATH": BASE_PATH + "/bin/media",
+        "RAINBOW_PATH": BASE_PATH + "/asynch/mouse/grids.py",
+        "REBOOT_PATH": BASE_PATH + "/bin/reboot.bat",
+        "REBOOT_PATH_WSR": BASE_PATH + "/bin/reboot_wsr.bat",
+        "SETTINGS_WINDOW_PATH": BASE_PATH + "/asynch/settingswindow.py",
+        "SIKULI_COMPATIBLE_JAVA_EXE_PATH": "",
+        "SIKULI_IDE_JAR_PATH": "",
+        "SIKULI_SCRIPTS_JAR_PATH": "",
+        "SIKULI_SERVER_PATH": BASE_PATH + "/asynch/sikuli/scripts/xmlrpc_server.sikuli",
+        "WSR_PATH": "C:/Windows/Speech/Common/sapisvr.exe",
+
+        # CCR
+        "CONFIGDEBUGTXT_PATH": BASE_PATH + "/bin/data/configdebug.txt",
+
+        # PYTHON
+        "WXPYTHON_PATH": "C:/Python27/Lib/site-packages/wx-3.0-msw"
+    },
+
+    # Apps Section
+    "apps": {
+        "atom": True,
+        "chrome": True,
+        "cmd": True,
+        "dragon": True,
+        "eclipse": True,
+        "emacs": True,
+        "explorer": True,
+        "firefox": True,
+        "flashdevelop": True,
+        "foxitreader": True,
+        "gitbash": True,
+        "kdiff3": True,
+        "douglas": True,
+        "legion": True,
+        "rainbow": True,
+        "ssms": True,
+        "jetbrains": True,
+        "msvc": True,
+        "notepadplusplus": True,
+        "sqldeveloper": True,
+        "sublime": True,
+        "visualstudio": True,
+        "winword": True,
+        "wsr": True,
+    },
+
+    # feature switches
+    "feature_rules": {
+        "hmc": True,
+        "again": True,
+        "alias": True,
+        "chainalias": True,
+    },
+
+    # node rules
+    "nodes": {},
+
+    # miscellaneous section
+    "miscellaneous": {
+        "dev_commands": False,
+        "sikuli_enabled": False,
+        "keypress_wait": 50, # milliseconds
+        "max_ccr_repetitions": 16,
+        "atom_palette_wait": "30",
+        "rdp_mode": False,
+        "integer_remap_opt_in": False,
+        "integer_remap_crash_fix": False,
+        "print_rdescripts": False,
+        "history_playback_delay_secs": 1.0,
+    },
+    "pronunciations": {
+        "c++": "C plus plus",
+        "jquery": "J query",
+    },
+    "one time warnings": {}
+}
+
+
+# Internal Methods
 def _save(data, path):
     '''only to be used for settings file'''
     try:
-        formatted_data = json.dumps(data, sort_keys=True, indent=4,
-            ensure_ascii=False)
+        formatted_data = json.dumps(data, sort_keys=True, indent=4, ensure_ascii=False)
         if not os.path.exists(path):
             f = open(path, "w")
             f.close()
@@ -43,173 +158,51 @@ def _save(data, path):
         f.write(formatted_data)
         f.close()
     except Exception:
-        print("error saving json file: " + path)
+        print "Error saving json file: " + path
 
-def _load(path):
-    '''only to be used for settings file'''
+def _init(path):
     result = {}
     try:
         f = open(path, "r")
         result = json.loads(f.read())
         f.close()
     except ValueError:
-        global BAD_LOAD 
-        BAD_LOAD = True
         print("\n\nValueError while loading settings file: " + path + "\n\n")
         print(sys.exc_info())
     except IOError:
         print("\n\nIOError: Could not find settings file: " + path + "\nInitializing file...\n\n")
+    result, num_default_added = _deep_merge_defaults(result, _DEFAULT_SETTINGS)
+    if num_default_added > 0:
+        print "Default settings values added: %d " % num_default_added
+        _save(result, _SETTINGS_PATH)
     return result
 
-def save_config():
-    global SETTINGS
-    global SETTINGS_PATH
-    global INISETPATH
-    _save(SETTINGS, INISETPATH if SETTINGS is None or not "SETTINGS" in SETTINGS.keys() else SETTINGS["SETTINGS_PATH"])
 
-def load_config():
-    global SETTINGS
-    global SETTINGS_PATH
-    global INISETPATH
-    SETTINGS = _load(INISETPATH if SETTINGS is None else SETTINGS["SETTINGS_PATH"])
-    init_default_values()
-
-def update_values(d, key_values):
-    values_change_count = 0
-    for key, value in key_values:
-        if not key in d:
-            d[key] = value
-            values_change_count += 1
-    return values_change_count
-
-def init_default_values():
-    global SETTINGS, BASE_PATH
-    values_change_count = 0
-    
-    # paths section
-    values_change_count += update_values(SETTINGS, [("paths", {})])
-    values_change_count += update_values(SETTINGS["paths"], [("BASE_PATH", BASE_PATH)])
-    values_change_count += update_values(SETTINGS["paths"], [
-        # DATA
-        ("DLL_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/lib/dll/"),
-        ("CCR_CONFIG_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/bin/data/ccr.json"),
-        ("SAVED_CLIPBOARD_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/bin/data/clipboard.json"),
-        ("RECORDED_MACROS_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/bin/data/recorded_macros.json"),
-        ("ALIAS_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/bin/data/aliases.json."),
-        ("LOG_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/bin/data/log.txt"),
-        ("SIKULI_SCRIPTS_FOLDER_PATH", SETTINGS["paths"]["BASE_PATH"] + "/asynch/sikuli/scripts"),
-        ("FILTER_DEFS_PATH", SETTINGS["paths"]["BASE_PATH"] + "/user/words.txt"),
-        
-        # REMOTE_DEBUGGER_PATH is the folder in which pydevd.py can be found
-        ("REMOTE_DEBUGGER_PATH" , "C:/PROG/alt ec/eclipse/plugins/org.python.pydev_3.9.2.201502050007/pysrc"),
-        
-        # EXECUTABLES
-        ("WSR_PATH", "C:/Windows/Speech/Common/sapisvr.exe"),
-        ("LEGION_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/asynch/mouse/legion.py"),
-        ("RAINBOW_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/asynch/mouse/grids.py"),
-        ("DOUGLAS_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/asynch/mouse/grids.py"),
-        ("HOMUNCULUS_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/asynch/hmc/h_launch.py"),
-        ("DEFAULT_BROWSER_PATH", "C:/Program Files (x86)/Mozilla Firefox/firefox.exe"),
-        ("SIKULI_IDE_JAR_PATH", ""),
-        ("SIKULI_SCRIPTS_JAR_PATH", ""),
-        ("SIKULI_SERVER_PATH", SETTINGS["paths"]["BASE_PATH"] + "/asynch/sikuli/scripts/xmlrpc_server.sikuli"),
-        ("SIKULI_COMPATIBLE_JAVA_EXE_PATH", ""),
-        ("ENGINE_PATH", "C:/Program Files (x86)/Nuance/NaturallySpeaking14/Program/natspeak.exe"),
-        ("REBOOT_PATH", SETTINGS["paths"]["BASE_PATH"] + "/bin/reboot.bat"),
-        ("REBOOT_PATH_WSR", SETTINGS["paths"]["BASE_PATH"] + "/bin/reboot_wsr.bat"),
-        ("SETTINGS_WINDOW_PATH", SETTINGS["paths"]["BASE_PATH"] + "/asynch/settingswindow.py"), 
-        
-        # CCR
-        ("CONFIGDEBUGTXT_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/bin/data/configdebug.txt"),
-                
-        # PYTHON
-        ("WXPYTHON_PATH" , "C:/Python27/Lib/site-packages/wx-3.0-msw"),
-                                  
-        ])
-    if not SETTINGS["paths"]["REMOTE_DEBUGGER_PATH"] in sys.path and os.path.isdir(SETTINGS["paths"]["REMOTE_DEBUGGER_PATH"]):
-        sys.path.append(SETTINGS["paths"]["REMOTE_DEBUGGER_PATH"])
-    if not SETTINGS["paths"]["WXPYTHON_PATH"] in sys.path and os.path.isdir(SETTINGS["paths"]["WXPYTHON_PATH"]):
-        sys.path.append(SETTINGS["paths"]["WXPYTHON_PATH"])
-        
-    # detect the version of Dragon
-    if not os.path.isfile(SETTINGS["paths"]["ENGINE_PATH"]):
-        dragon_13_path = "C:/Program Files (x86)/Nuance/NaturallySpeaking13/Program/natspeak.exe"
-        dragon_12_path = "C:/Program Files (x86)/Nuance/NaturallySpeaking12/Program/natspeak.exe"
-        if os.path.isfile(dragon_13_path):
-            SETTINGS["paths"]["ENGINE_PATH"] = dragon_13_path
-        elif os.path.isfile(dragon_12_path):
-            SETTINGS["paths"]["ENGINE_PATH"] = dragon_12_path
+def _deep_merge_defaults(data, defaults):
+    '''
+    Recursivly merge data and defaults, preferring data.
+    Only handles nested dicts and scalar values.
+    Modifies `data` in place.
+    '''
+    changes = 0
+    for key, default_value in defaults.iteritems():
+        # If the key is in the data, use that, but call recursivly if it's a dict.
+        if(key in data):
+            if(isinstance(data[key], collections.Mapping)):
+                child_data, child_changes = _deep_merge_defaults(data[key], default_value)
+                data[key] = child_data
+                changes += child_changes
         else:
-            print("Cannot find default dragon engine path")
-    
-    # apps section
-    values_change_count += update_values(SETTINGS, [("apps", {})])
-    values_change_count += update_values(SETTINGS["apps"], [
-                       ("atom", True), 
-                       ("chrome", True),
-                       ("cmd", True),
-                       ("dragon", True),
-                       ("eclipse", True),
-                       ("emacs", True),
-                       ("explorer", True),
-                       ("firefox", True),
-                       ("flashdevelop", True),
-                       ("foxitreader", True),
-                       ("gitbash", True),
-                       ("kdiff3", True),
-                       ("douglas", True),
-                       ("legion", True),
-                       ("rainbow", True),
-                       ("ssms", True),
-                       ("jetbrains", True),
-                       ("msvc", True),
-                       ("notepadplusplus", True),
-                       ("sqldeveloper", True),
-                       ("sublime", True),
-                       ("visualstudio", True),
-                       ("winword", True),
-                       ("wsr", True),
-                       ])
-    
-    # feature switches
-    values_change_count += update_values(SETTINGS, [("feature_rules", {})])
-    values_change_count += update_values(SETTINGS["feature_rules"], [
-                       ("hmc", True),
-                       ("again", True),
-                       ("alias", True),
-                       ("chainalias", True),
-                       ])
-    
-    # node rules
-    values_change_count += update_values(SETTINGS, [("nodes", {})])
-    
-    # miscellaneous section
-    values_change_count += update_values(SETTINGS, [("miscellaneous", {})])
-                       ("dev_commands", False),
-                       ("sikuli_enabled", False),
-                       ("keypress_wait", 50), # milliseconds
-                       ("max_ccr_repetitions", 16), 
-                       ("atom_palette_wait", "30"),
-                       ("rdp_mode", False),
-                       ("integer_remap_opt_in", False), 
-                       ("integer_remap_crash_fix", False),
-                       ("print_rdescripts", False),
-                       ("history_playback_delay_secs", 1.0)
-                       ])
-    
-    # pronunciations section
-    values_change_count += update_values(SETTINGS, [("pronunciations", {})])
-    values_change_count += update_values(SETTINGS["pronunciations"], [
-        ("c++", "C plus plus"),
-        ("jquery", "J query"),
-        ])
-    
-    values_change_count += update_values(SETTINGS, [("one time warnings", {})])
-    
-    global BAD_LOAD
-    if values_change_count > 0 and not BAD_LOAD:
-        print("settings values changed: "+ str(values_change_count))
-        save_config()
+            data[key] = default_value
+            changes += 1
+    return data, changes
+
+
+
+# Public interface:
+def save_config():
+    '''Save the current in-memory settings to disk'''
+    _save(SETTINGS, _SETTINGS_PATH)
 
 def get_settings():
     global SETTINGS
@@ -220,11 +213,18 @@ def get_default_browser_executable():
     return SETTINGS["paths"]["DEFAULT_BROWSER_PATH"].split("/")[-1]
 
 def report_to_file(message, path=None):
-    global SETTINGS
     _path = SETTINGS["paths"]["LOG_PATH"]
     if path is not None: _path = path
-    f = open(_path, 'a') 
+    f = open(_path, 'a')
     f.write(str(message) + "\n")
     f.close()
 
-load_config()
+
+## Kick everything off.
+SETTINGS = _init(_SETTINGS_PATH)
+for path in [
+        SETTINGS["paths"]["REMOTE_DEBUGGER_PATH"],
+        SETTINGS["paths"]["WXPYTHON_PATH"]
+    ]:
+    if not path in sys.path and os.path.isdir(path):
+        sys.path.append(path)

--- a/caster/lib/settings.py
+++ b/caster/lib/settings.py
@@ -11,7 +11,6 @@ BASE_PATH = os.path.realpath(__file__).split("\\lib")[0].replace("\\", "/")
 SOFTWARE_VERSION_NUMBER = "0.5.8"
 SOFTWARE_NAME = "Caster v " + SOFTWARE_VERSION_NUMBER
 HOMUNCULUS_VERSION = "HMC v " + SOFTWARE_VERSION_NUMBER
-HMC_TITLE_VOCABULARY = " :: Vocabulary Manager"
 HMC_TITLE_RECORDING = " :: Recording Manager"
 HMC_TITLE_DIRECTORY = " :: Directory Selector"
 HMC_TITLE_CONFIRM = " :: Confirm"
@@ -93,9 +92,7 @@ def init_default_values():
     values_change_count += update_values(SETTINGS["paths"], [
         # DATA
         ("DLL_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/lib/dll/"),
-        ("SETTINGS_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/bin/data/settings.json"),
         ("CCR_CONFIG_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/bin/data/ccr.json"),
-        ("S_LIST_JSON_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/bin/data/s_list.json"),
         ("SAVED_CLIPBOARD_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/bin/data/clipboard.json"),
         ("RECORDED_MACROS_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/bin/data/recorded_macros.json"),
         ("ALIAS_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/bin/data/aliases.json."),
@@ -125,10 +122,6 @@ def init_default_values():
         # CCR
         ("CONFIGDEBUGTXT_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/bin/data/configdebug.txt"),
                 
-        # MISC
-        ("ALARM_SOUND_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/bin/media/49685__ejfortin__nano-blade-loop.wav"),
-        ("MEDIA_PATH" , SETTINGS["paths"]["BASE_PATH"] + "/bin/media"),
-        
         # PYTHON
         ("WXPYTHON_PATH" , "C:/Python27/Lib/site-packages/wx-3.0-msw"),
                                   
@@ -190,24 +183,12 @@ def init_default_values():
     # node rules
     values_change_count += update_values(SETTINGS, [("nodes", {})])
     
-    # passwords section
-    values_change_count += update_values(SETTINGS, [("password", {})])
-    values_change_count += update_values(SETTINGS["password"], [
-                       ("seed1", "change these"), 
-                       ("seed2", "if you use"),
-                       ("seed3", "password"),
-                       ("seed4", "generation")
-                       ])
-    
     # miscellaneous section
     values_change_count += update_values(SETTINGS, [("miscellaneous", {})])
-    values_change_count += update_values(SETTINGS["miscellaneous"], [
-                       ("debug_speak", False), 
                        ("dev_commands", False),
                        ("sikuli_enabled", False),
                        ("keypress_wait", 50), # milliseconds
                        ("max_ccr_repetitions", 16), 
-                       ("enable_match_logging", False),
                        ("atom_palette_wait", "30"),
                        ("rdp_mode", False),
                        ("integer_remap_opt_in", False), 


### PR DESCRIPTION
This PR:
 - Removes some unused default settings values
 - Refactors settings.py with
   - More docstrings
   - More PEP-8 formatting
   - Fewer global mutations
   - Separates public and private methods
   - Moves to merging a default nested dict against the live settings. This allows separating out the defaults in the future.

On my machine, I can boot with a vanilla generated settings file and create one from scratch as needed.
The diff of generated settings files is here: https://www.diffchecker.com/KT7nL3P0