### PR TITLE
Remove unused rule data

### DIFF
--- a/caster/lib/ccr/cpp/cpp.py
+++ b/caster/lib/ccr/cpp/cpp.py
@@ -7,7 +7,7 @@ from dragonfly import Key, Mimic, Text
 
 from caster.lib import control
 from caster.lib.ccr.standard import SymbolSpecs
-from caster.lib.dfplus.merge.mergerule import MergeRule, TokenSet
+from caster.lib.dfplus.merge.mergerule import MergeRule
 from caster.lib.dfplus.state.short import R
 
 
@@ -90,24 +90,5 @@ class CPP(MergeRule):
 
     extras   = []
     defaults = {}
-    
-    token_set = TokenSet(["alignas", "alignof", "and", "and_eq", "asm", "auto", 
-                "bitand", "bitor", "bool", "break", "case", "catch", 
-                "char", "char16_t", "char32_t", "class", "compl", 
-                "concept", "const", "constexpr", "const_cast", "continue", 
-                "decltype", "default", "delete", "do", "double", 
-                "dynamic_cast", "else", "enum", "explicit", "export", 
-                "extern", "false", "float", "for", "friend", "goto", "if", 
-                "inline", "int", "long", "mutable", "namespace", "new", 
-                "noexcept", "not", "not_eq", "nullptr", "operator", "or", 
-                "or_eq", "private", "protected", "public", "register", 
-                "reinterpret_cast", "requires", "return", "short", "signed", 
-                "sizeof", "static", "static_assert", "static_cast", "struct", 
-                "switch", "template", "this", "thread_local", "throw", "true", 
-                "try", "typedef", "typeid", "typename", "union", "unsigned", 
-                "using", "virtual", "void", "volatile", "wchar_t", "while", 
-                "xor", "xor_eq"   ], 
-                         "//", 
-                         ["/*", "*/"])
 
 control.nexus().merger.add_global_rule(CPP())

--- a/caster/lib/ccr/cpp/cpp.py
+++ b/caster/lib/ccr/cpp/cpp.py
@@ -12,7 +12,6 @@ from caster.lib.dfplus.state.short import R
 
 
 class CPP(MergeRule):
-    auto = [".h",".cpp"]
     pronunciation = "C plus plus"
         
     mapping = {

--- a/caster/lib/ccr/csharp/csharp.py
+++ b/caster/lib/ccr/csharp/csharp.py
@@ -13,7 +13,6 @@ from caster.lib.dfplus.state.short import R
 
 
 class CSharp(MergeRule):
-    auto = [".cs", ".cshtml"]
     pronunciation = "C sharp"
         
     mapping = {

--- a/caster/lib/ccr/haxe/haxe.py
+++ b/caster/lib/ccr/haxe/haxe.py
@@ -8,7 +8,6 @@ from caster.lib.dfplus.state.short import R
 
 
 class Haxe(MergeRule):
-    auto = [".hx"]
     pronunciation = "hacks"
         
     mapping = {

--- a/caster/lib/ccr/java/java.py
+++ b/caster/lib/ccr/java/java.py
@@ -2,7 +2,7 @@ from dragonfly import Key, Text, Paste, MappingRule
 
 from caster.lib import control
 from caster.lib.ccr.standard import SymbolSpecs
-from caster.lib.dfplus.merge.mergerule import MergeRule, TokenSet
+from caster.lib.dfplus.merge.mergerule import MergeRule
 from caster.lib.dfplus.state.short import R
 
 
@@ -103,21 +103,5 @@ class Java(MergeRule):
 
     extras   = []
     defaults = {}
-    
-    token_set = TokenSet(["abstract", "continue", "for", "new", "switch", "assert",
-                 "default", "goto", "package", "synchronized", "boolean",
-                 "do", "if", "private", "this", "break", "double",
-                 "implements", "protected", "throw", "byte", "else",
-                 "import", "public", "throws", "case", "enum",
-                 "instanceof", "return", "transient", "catch", "extends",
-                 "int", "short", "try", "char", "final", "interface",
-                 "static", "void", "class", "finally", "long", "strictfp",
-                 "volatile", "const", "float", "native", "super", "while"], 
-                         "//", 
-                         ["/*", "*/"])
-
-
-
-
 
 control.nexus().merger.add_global_rule(Java())

--- a/caster/lib/ccr/java/java.py
+++ b/caster/lib/ccr/java/java.py
@@ -18,7 +18,6 @@ class JavaNon(MappingRule):
     ncdefaults = {}
 
 class Java(MergeRule):
-    auto = [".java"]
     non = JavaNon
         
     mapping = {

--- a/caster/lib/ccr/javascript/javascript.py
+++ b/caster/lib/ccr/javascript/javascript.py
@@ -13,7 +13,6 @@ from caster.lib.dfplus.state.short import R
 
 
 class Javascript(MergeRule):
-    auto = [".js"]
         
     mapping = {
         

--- a/caster/lib/ccr/javascript/javascript.py
+++ b/caster/lib/ccr/javascript/javascript.py
@@ -8,7 +8,7 @@ from dragonfly import Key, Text
 from caster.lib import control
 from caster.lib.ccr.standard import SymbolSpecs
 from caster.lib.dfplus.additions import SelectiveAction
-from caster.lib.dfplus.merge.mergerule import MergeRule, TokenSet
+from caster.lib.dfplus.merge.mergerule import MergeRule
 from caster.lib.dfplus.state.short import R
 
 
@@ -92,27 +92,5 @@ class Javascript(MergeRule):
 
     extras = []
     defaults = {}
-    
-    token_set = TokenSet(["abstract", "arguments", "boolean", "break", "byte",
-                 "case", "catch", "char", "class", "const", "continue",
-                 "debugger", "default", "delete", "do", "double", "else",
-                 "enum", "eval", "export", "extends", "false", "final",
-                 "finally", "float", "for", "function", "goto", "if",
-                 "implements", "import", "in", "instanceof", "int",
-                 "interface", "let", "long", "native", "new", "null",
-                 "package", "private", "protected", "public", "return",
-                 "short", "static", "super", "switch", "synchronized",
-                 "this", "throw", "throws", "transient", "true", "try",
-                 "typeof", "var", "void", "volatile", "while", "with",
-                 "yield"],
-                         "//",
-                         ["/*", "*/"])
-    
-    
-    
-    
-    
-    
-    
-    
+
 control.nexus().merger.add_global_rule(Javascript(ID=200))

--- a/caster/lib/ccr/python/python.py
+++ b/caster/lib/ccr/python/python.py
@@ -21,7 +21,6 @@ class PythonNon(MappingRule):
         }
 
 class Python(MergeRule):
-    auto = [".py"]
     non = PythonNon
     
     mapping = {        

--- a/caster/lib/ccr/python/python.py
+++ b/caster/lib/ccr/python/python.py
@@ -7,7 +7,7 @@ from dragonfly import Key, Text, Dictation, MappingRule
 
 from caster.lib import control
 from caster.lib.ccr.standard import SymbolSpecs
-from caster.lib.dfplus.merge.mergerule import MergeRule, TokenSet
+from caster.lib.dfplus.merge.mergerule import MergeRule
 from caster.lib.dfplus.state.short import R
 
 
@@ -90,13 +90,5 @@ class Python(MergeRule):
 
     extras   = [Dictation("text"),]
     defaults = {}
-    
-    token_set = TokenSet(["and", "del", "from", "not", "while", "as", "elif",
-                 "global", "or", "with", "assert", "else", "if", "pass",
-                 "yield", "break", "except", "import", "print", "class",
-                 "exec", "in", "raise", "continue", "finally", "is",
-                 "return", "def", "for", "lambda", "try"], 
-                         "#", 
-                         ["'''", '"""'])
 
 control.nexus().merger.add_global_rule(Python(ID=100))

--- a/caster/lib/ccr/rust/rust.py
+++ b/caster/lib/ccr/rust/rust.py
@@ -25,7 +25,6 @@ class RustNon(MappingRule):
         }
 
 class Rust(MergeRule):
-    auto = [".rs"]
     non = RustNon
     
     mapping = {

--- a/caster/lib/dfplus/merge/mergerule.py
+++ b/caster/lib/dfplus/merge/mergerule.py
@@ -3,17 +3,7 @@ Created on Sep 1, 2015
 
 @author: synkarius
 '''
-import re
-
 from dragonfly import MappingRule, Pause, Function
-
-
-class TokenSet(object):
-    SYMBOL_PATTERN = re.compile("([A-Za-z0-9_]+)")
-    def __init__(self, keywords, line_comment, long_comment):
-        self.keywords = keywords
-        self.line_comment = line_comment
-        self.long_comment = long_comment
 
 class MergeRule(MappingRule):
     @staticmethod


### PR DESCRIPTION
This pull quest removes the `auto` and `token_set` properties as discussed in #192

Ideally this should make the code base easier to approach as a beginner, because there are fewer things to get tripped up on.