### PR TITLE
Partial format

### DIFF
--- a/caster/lib/ccr/core/nav.py
+++ b/caster/lib/ccr/core/nav.py
@@ -167,7 +167,7 @@ class Navigation(MergeRule):
         Choice("semi",
                     {"dock": ";", "doc": ";", "sink": ""
                     }),
-        Choice("word_limit",{"single": 1,"double": 2,"triple":3}),
+        Choice("word_limit",{"single": 1,"double": 2,"triple":3,"Quadra":4}),
           
           
           

--- a/caster/lib/ccr/core/nav.py
+++ b/caster/lib/ccr/core/nav.py
@@ -148,7 +148,7 @@ class Navigation(MergeRule):
     "peek format":                  R(Function(textformat.peek_text_format), rdescript="Peek Format"),
     "(<capitalization> <spacing> | <capitalization> | <spacing>) (bow|bowel) <textnv> [brunt]":  R(Function(textformat.master_format_text), rdescript="Text Format"), 
     "format <textnv>":              R(Function(textformat.prior_text_format), rdescript="Last Text Format"),
-    
+    "<word_limit> format <textnv>": R(Function(textformat.partial_format_text), rdescript="Partial Text Format"),
     "dredge":                       R(Key("a-tab"), rdescript="Alt-Tab"),
 
     }
@@ -167,6 +167,7 @@ class Navigation(MergeRule):
         Choice("semi",
                     {"dock": ";", "doc": ";", "sink": ""
                     }),
+        Choice("word_limit",{"single": 1,"double": 2,"triple":3}),
           
           
           

--- a/caster/lib/textformat.py
+++ b/caster/lib/textformat.py
@@ -68,9 +68,9 @@ def master_format_text(capitalization, spacing, textnv):
     capitalization, spacing = normalize_text_format(capitalization, spacing)
     Text(get_formatted_text(capitalization, spacing, str(textnv))).execute()
 
-def partial_format_text(word_limit,capitalization, spacing, textnv):   
-    capitalization, spacing = normalize_text_format(capitalization, spacing)
-    Text(get_formatted_text(capitalization, spacing, " ".join(str(textnv).split(" ")[0:word_limit]))).execute()
+def partial_format_text(word_limit,capitalization, spacing, textnv):
+    global _CAPITALIZATION, _SPACING   
+    Text(get_formatted_text(_CAPITALIZATION, _SPACING, " ".join(str(textnv).split(" ")[0:word_limit]))).execute()
 
 def get_formatted_text(capitalization, spacing, t):
     tlen = len(t)

--- a/caster/lib/textformat.py
+++ b/caster/lib/textformat.py
@@ -68,7 +68,7 @@ def master_format_text(capitalization, spacing, textnv):
     capitalization, spacing = normalize_text_format(capitalization, spacing)
     Text(get_formatted_text(capitalization, spacing, str(textnv))).execute()
 
-def partial_format_text(word_limit,capitalization, spacing, textnv):
+def partial_format_text(word_limit,textnv):
     global _CAPITALIZATION, _SPACING   
     Text(get_formatted_text(_CAPITALIZATION, _SPACING, " ".join(str(textnv).split(" ")[0:word_limit]))).execute()
 

--- a/caster/lib/textformat.py
+++ b/caster/lib/textformat.py
@@ -66,7 +66,11 @@ def get_text_format_description(capitalization, spacing):
 
 def master_format_text(capitalization, spacing, textnv):
     capitalization, spacing = normalize_text_format(capitalization, spacing)
-    Text(get_formatted_text(capitalization, spacing, str(textnv))).execute()    
+    Text(get_formatted_text(capitalization, spacing, str(textnv))).execute()
+
+def partial_format_text(word_limit,capitalization, spacing, textnv):   
+    capitalization, spacing = normalize_text_format(capitalization, spacing)
+    Text(get_formatted_text(capitalization, spacing, " ".join(str(textnv).split(" ")[0:word_limit]))).execute()
 
 def get_formatted_text(capitalization, spacing, t):
     tlen = len(t)


### PR DESCRIPTION
I have added a partial format command which allows the user to utter any dictation but keep the first n (1 up to 4) words. The rest of the dictation is used as context to improve the accuracy of the first words. Example usage:"single format end of time"=>"end", which minimizes the chances of Dragon actually outputting "and" while at the same time not polluting the command pool with new commands.