### PR TITLE
Unicode fixes

### DIFF
--- a/caster/lib/dfplus/merge/gfilter.py
+++ b/caster/lib/dfplus/merge/gfilter.py
@@ -1,25 +1,26 @@
 ################################# Global Filter Functions From File module  ############################################
 '''GlobalFilterDefs overrides ALL instances of some word(s) in all rules'''
 
+import io
 import os
 
+from caster.lib import settings
+from caster.lib.dfplus.merge.mergepair import MergeInf, MergePair
 from dragonfly.grammar.elements import Choice
 
-from caster.lib import settings
-from caster.lib.dfplus.merge.mergepair import MergePair, MergeInf
 
 class PreservedSpec(object):
     def __init__(self):
-        self.original = None # original spec from Caster
-        self.extras = [] # bound extras' words
-        self.cleaned = None # original with bound extras replaced with '?'s
-        self.altered = None # 'cleaned' after replacement process
-    
+        self.original = None  # original spec from Caster
+        self.extras = []  # bound extras' words
+        self.cleaned = None  # original with bound extras replaced with '?'s
+        self.altered = None  # 'cleaned' after replacement process
+
     @staticmethod
     def preserve(spec):
         p = PreservedSpec()
         p.original = spec
-        
+
         angles_mode = False
         preserved_word = ""
         cleaned_spec = ""
@@ -40,71 +41,69 @@ class PreservedSpec(object):
                 cleaned_spec += c
         p.cleaned = cleaned_spec
         p.altered = cleaned_spec
-        
+
         return p
-    
+
     @staticmethod
     def restore(pspec):
         p = pspec
-        
+
         q = p.altered.split("?")
-        if len(q) == 1: # no bound extras
-            return p.altered # so just return the gfilter result
-        
+        if len(q) == 1:  # no bound extras
+            return p.altered  # so just return the gfilter result
+
         # intersperse the lists
         c = [b for a in map(None, q, p.extras) for b in a if b is not None]
-        
+
         return "".join(c)
 
+
 class GlobalFilterDefs(object):
-    
-    
-    
+
     P = "<?>"
-    
+
     @staticmethod
     def preserve(spec, target):
-        _ = "<"+target+">"
+        _ = "<" + target + ">"
         if _ in spec:
             return spec.replace(_, GlobalFilterDefs.P)
         else:
             return spec
-    
-    @staticmethod        
+
+    @staticmethod
     def restore(spec, target):
-        return spec.replace(GlobalFilterDefs.P, "<"+target+">")
-    
-    
+        return spec.replace(GlobalFilterDefs.P, "<" + target + ">")
+
     '''parsing modes'''
     MODES = {
-             "<<<ANY>>>":       0,
-             "<<<SPEC>>>":      1,
-             "<<<EXTRA>>>":     2,
-             "<<<DEFAULT>>>":   3,
-             "<<<NOT_SPECS>>>": 4
-            }
-    
+        "<<<ANY>>>": 0,
+        "<<<SPEC>>>": 1,
+        "<<<EXTRA>>>": 2,
+        "<<<DEFAULT>>>": 3,
+        "<<<NOT_SPECS>>>": 4
+    }
+
     def __init__(self, lines):
         self.specs = {}
         self.extras = {}
         self.defaults = {}
         mode = 0
-        
+
         for line in lines:
-            
-            if line.startswith("#") or not line.strip(): # ignore comments and empty lines
+
+            if line.startswith(
+                    "#") or not line.strip():  # ignore comments and empty lines
                 continue
-            
+
             pair = line.split("->")
             original = pair[0].strip()
-            
+
             if original in GlobalFilterDefs.MODES:
                 mode = GlobalFilterDefs.MODES[original]
                 continue
-            
+
             new = pair[1].strip()
             new = "#".join(new.split("#")[:1])
-            
             '''only handles mode 1 for now'''
             if mode == 0:
                 self.specs[original] = new
@@ -125,59 +124,62 @@ DEFS = None
 
 if os.path.isfile(settings.SETTINGS["paths"]["FILTER_DEFS_PATH"]):
     '''user must create caster/user/fdefs.txt for it to get picked up here'''
-    with open(settings.SETTINGS["paths"]["FILTER_DEFS_PATH"]) as f:
+    with io.open(
+            settings.SETTINGS["paths"]["FILTER_DEFS_PATH"], "rt", encoding="utf-8") as f:
         lines = f.readlines()
         try:
             DEFS = GlobalFilterDefs(lines)
         except Exception:
             print("Unable to parse words.txt")
 
+
 def spec_override_from_config(mp):
     '''run at boot time only: changes are permanent'''
-    if mp.time != MergeInf.BOOT_NO_MERGE: # 3 == MergeInf.BOOT
+    if mp.time != MergeInf.BOOT_NO_MERGE:  # 3 == MergeInf.BOOT
         return
     '''redundant safety check'''
     if DEFS is None:
         return
-    
+
     for rule in [mp.rule1, mp.rule2]:
         if rule is not None:
             '''SPECS'''
             specs_changed = False
             for spec in rule.mapping_actual().keys():
                 action = rule.mapping_actual()[spec]
-                
+
                 pspec = PreservedSpec.preserve(spec)
-                
+
                 for original in DEFS.specs.keys():
                     if original in pspec.altered:
                         new = DEFS.specs[original]
                         pspec.altered = pspec.altered.replace(original, new)
-                        
+
                 pspec.altered = PreservedSpec.restore(pspec)
-                        
+
                 if spec == pspec.altered:
-                    continue;
-                
+                    continue
+
                 del rule.mapping_actual()[spec]
                 rule.mapping_actual()[pspec.altered] = action
                 specs_changed = True
-                
-            
             '''EXTRAS'''
             extras = rule.extras_copy().values()
             extras_changed = False
             if len(extras) > 0:
                 replacements = {}
                 for extra in extras:
-                    if isinstance(extra, Choice): # IntegerRefSTs will be dealt with elsewhere
+                    if isinstance(extra,
+                                  Choice):  # IntegerRefSTs will be dealt with elsewhere
                         choices = extra._choices
                         replace = False
-                        for s in choices.keys(): #ex: "dunce make" is key, some int or whatever is the value
-                            for ns in DEFS.extras.keys(): #ex: "dunce" is key, "down" is the value
-                                if ns in s: # ex: "dunce" is in "dunce make"
+                        for s in choices.keys(
+                        ):  #ex: "dunce make" is key, some int or whatever is the value
+                            for ns in DEFS.extras.keys(
+                            ):  #ex: "dunce" is key, "down" is the value
+                                if ns in s:  # ex: "dunce" is in "dunce make"
                                     replace = True
-                                    val = choices[s] 
+                                    val = choices[s]
                                     del choices[s]
                                     s = s.replace(ns, DEFS.extras[ns])
                                     choices[s] = val
@@ -190,21 +192,21 @@ def spec_override_from_config(mp):
                     extras.append(new_choice)
                 if len(replacements) > 0:
                     extras_changed = True
-            
             '''DEFAULTS'''
             defaults = rule.defaults_copy()
             defaults_changed = False
             if len(defaults) > 0:
                 replacements = {}
-                for default_key in defaults.keys(): # 
+                for default_key in defaults.keys():  #
                     value = defaults[default_key]
                     if isinstance(value, basestring):
                         '''only replace strings; also,
                         only replace values, not keys:
                         default_key should not be changed - it will never be spoken'''
-                        nvalue = value # new value
+                        nvalue = value  # new value
                         replace = False
-                        for old in DEFS.defaults.keys(): # 'old' is the target word(s) in the old 'value'
+                        for old in DEFS.defaults.keys(
+                        ):  # 'old' is the target word(s) in the old 'value'
                             new = DEFS.defaults[old]
                             if old in nvalue:
                                 nvalue = nvalue.replace(old, new)
@@ -212,17 +214,18 @@ def spec_override_from_config(mp):
                         if replace:
                             defaults[default_key] = nvalue
                             defaults_changed = True
-            
+
             if specs_changed or extras_changed or defaults_changed:
-                rule.__init__(rule._name, rule.mapping_actual(), extras, defaults, rule._exported,
-                              rule.ID, rule.composite, rule.compatible, rule._mcontext, rule._mwith)
-                        
+                rule.__init__(rule._name, rule.mapping_actual(), extras, defaults,
+                              rule._exported, rule.ID, rule.composite, rule.compatible,
+                              rule._mcontext, rule._mwith)
+
 
 if DEFS is not None:
     print("Global rule filter from file 'words.txt' activated ...")
-    
+
+
 def run_on(rule):
     if DEFS is not None:
         mp = MergePair(MergeInf.BOOT_NO_MERGE, MergeInf.GLOBAL, None, rule, False)
         spec_override_from_config(mp)
-    

--- a/caster/lib/navigation.py
+++ b/caster/lib/navigation.py
@@ -1,33 +1,47 @@
+# -*- coding: utf-8 -*-
 '''
 master_text_nav shouldn't take strings as arguments - it should take ints, so it can be language-agnostic
 '''
 
+import time
 from ctypes import windll
 from subprocess import Popen
-import time
 
-from dragonfly import (Key, Text, Choice, Mouse, monitors)
 import dragonfly
-from win32clipboard import (CF_TEXT, CF_UNICODETEXT, OpenClipboard, CloseClipboard, EmptyClipboard,
-                            GetClipboardData, SetClipboardText, GetPriorityClipboardFormat)
-
 from caster.asynch.mouse.legion import LegionScanner
-from caster.lib import utilities, settings
+from caster.lib import settings, utilities
+from dragonfly import Choice, Key, Mouse, Text, monitors
+from win32clipboard import (CF_TEXT, CF_UNICODETEXT, CloseClipboard,
+                            EmptyClipboard, GetClipboardData,
+                            GetPriorityClipboardFormat, OpenClipboard,
+                            SetClipboardText)
 
-DIRECTION_STANDARD = {"sauce [E]": "up", "dunce [E]": "down",
-                      "lease [E]": "left", "Ross [E]": "right", "back": "left"}
-
-''''
+DIRECTION_STANDARD = {
+    "sauce [E]": "up",
+    "dunce [E]": "down",
+    "lease [E]": "left",
+    "Ross [E]": "right",
+    "back": "left"
+}
+'''
 Note: distinct token types were removed because
 A) a general purpose fill token is easier to remember than 10 of them, and
 B) the user of a programming language will know what they're supposed to get filled with
 '''
-TARGET_CHOICE = Choice("target",
-                       {"comma": ",", "(period | dot)": ".", "(pair | parentheses)": "(~)",
-                        "[square] (bracket | brackets)": "[~]", "curly [brace]": "{~}",
-                        "loop": "for~while", "L paren": "(", "are paren": ")", "openers": "(~[~{",
-                        "closers": "}~]~)", "token": "TOKEN"}
-                       )
+TARGET_CHOICE = Choice(
+    "target", {
+        "comma": ",",
+        "(period | dot)": ".",
+        "(pair | parentheses)": "(~)",
+        "[square] (bracket | brackets)": "[~]",
+        "curly [brace]": "{~}",
+        "loop": "for~while",
+        "L paren": "(",
+        "are paren": ")",
+        "openers": "(~[~{",
+        "closers": "}~]~)",
+        "token": "TOKEN"
+    })
 
 
 def get_direction_choice(name):
@@ -45,19 +59,30 @@ def mouse_alternates(mode, nexus, monitor=1):
     if nexus.dep.PIL:
         if mode == "legion" and not utilities.window_exists(None, "legiongrid"):
             r = monitors[int(monitor) - 1].rectangle
-            bbox = [int(r.x), int(r.y), int(r.x) +
-                    int(r.dx) - 1, int(r.y) + int(r.dy) - 1]
+            bbox = [
+                int(r.x),
+                int(r.y),
+                int(r.x) + int(r.dx) - 1,
+                int(r.y) + int(r.dy) - 1
+            ]
             ls = LegionScanner()
             ls.scan(bbox)
             tscan = ls.get_update()
-            Popen(["pythonw", settings.SETTINGS["paths"]["LEGION_PATH"], "-t",
-                   tscan[0], "-m", str(monitor)])  # , "-d", "500_500_500_500"
+            Popen([
+                "pythonw", settings.SETTINGS["paths"]["LEGION_PATH"], "-t", tscan[0],
+                "-m",
+                str(monitor)
+            ])  # , "-d", "500_500_500_500"
         elif mode == "rainbow" and not utilities.window_exists(None, "rainbowgrid"):
-            Popen(["pythonw", settings.SETTINGS["paths"]
-                   ["RAINBOW_PATH"], "-g", "r", "-m", str(monitor)])
+            Popen([
+                "pythonw", settings.SETTINGS["paths"]["RAINBOW_PATH"], "-g", "r", "-m",
+                str(monitor)
+            ])
         elif mode == "douglas" and not utilities.window_exists(None, "douglasgrid"):
-            Popen(["pythonw", settings.SETTINGS["paths"]
-                   ["DOUGLAS_PATH"], "-g", "d", "-m", str(monitor)])
+            Popen([
+                "pythonw", settings.SETTINGS["paths"]["DOUGLAS_PATH"], "-g", "d", "-m",
+                str(monitor)
+            ])
     else:
         utilities.availability_message(mode.title(), "PIL")
 
@@ -73,16 +98,14 @@ def clipboard_to_file(nnavi500, nexus, do_copy=False):
         failure = False
         try:
             # time for keypress to execute
-            time.sleep(
-                 settings.SETTINGS["miscellaneous"]["keypress_wait"] / 1000.)
+            time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"] / 1000.)
             OpenClipboard()
-            fmt = GetPriorityClipboardFormat(
-                (CF_UNICODETEXT, CF_TEXT))
+            fmt = GetPriorityClipboardFormat((CF_UNICODETEXT, CF_TEXT))
             if fmt > 0:
                 nexus.clip[key] = GetClipboardData(fmt)
             CloseClipboard()
-            utilities.save_json_file(
-                nexus.clip, settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
+            utilities.save_json_file(nexus.clip,
+                                     settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
         except Exception:
             failure = True
             utilities.simple_log()
@@ -98,13 +121,12 @@ def drop(nnavi500, nexus):
             if key in nexus.clip:
                 OpenClipboard()
                 EmptyClipboard()
-                SetClipboardText(nexus.clip[key])
+                SetClipboardText(nexus.clip[key], CF_UNICODETEXT)
                 CloseClipboard()
                 Key("c-v").execute()
             else:
                 dragonfly.get_engine().speak("slot empty")
-            time.sleep(
-                settings.SETTINGS["miscellaneous"]["keypress_wait"] / 1000.)
+            time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"] / 1000.)
         except Exception:
             failure = True
         if not failure:
@@ -113,8 +135,8 @@ def drop(nnavi500, nexus):
 
 def erase_multi_clipboard(nexus):
     nexus.clip = {}
-    utilities.save_json_file(
-        nexus.clip, settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
+    utilities.save_json_file(nexus.clip,
+                             settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
 
 
 def volume_control(n, volume_mode):
@@ -124,7 +146,8 @@ def volume_control(n, volume_mode):
 
 def kill_grids_and_wait(nexus):
     window_title = utilities.get_active_window_title()
-    if window_title == settings.RAINBOW_TITLE or window_title == settings.DOUGLAS_TITLE or window_title == settings.LEGION_TITLE:
+    if (window_title == settings.RAINBOW_TITLE or window_title == settings.DOUGLAS_TITLE
+            or window_title == settings.LEGION_TITLE):
         nexus.comm.get_com("grids").kill()
         time.sleep(0.1)
 

--- a/caster/lib/navigation.py
+++ b/caster/lib/navigation.py
@@ -8,12 +8,14 @@ import time
 
 from dragonfly import (Key, Text, Choice, Mouse, monitors)
 import dragonfly
-import win32clipboard
+from win32clipboard import (CF_TEXT, CF_UNICODETEXT, OpenClipboard, CloseClipboard, EmptyClipboard,
+                            GetClipboardData, SetClipboardText, GetPriorityClipboardFormat)
 
 from caster.asynch.mouse.legion import LegionScanner
 from caster.lib import utilities, settings
 
-DIRECTION_STANDARD={"sauce [E]": "up", "dunce [E]": "down", "lease [E]": "left", "Ross [E]": "right", "back": "left" }
+DIRECTION_STANDARD = {"sauce [E]": "up", "dunce [E]": "down",
+                      "lease [E]": "left", "Ross [E]": "right", "back": "left"}
 
 ''''
 Note: distinct token types were removed because
@@ -21,59 +23,72 @@ A) a general purpose fill token is easier to remember than 10 of them, and
 B) the user of a programming language will know what they're supposed to get filled with
 '''
 TARGET_CHOICE = Choice("target",
-                            {"comma": ",", "(period | dot)": ".", "(pair | parentheses)": "(~)",
-                            "[square] (bracket | brackets)": "[~]", "curly [brace]": "{~}",
-                            "loop": "for~while", "L paren": "(", "are paren": ")", "openers": "(~[~{",
-                            "closers": "}~]~)", "token": "TOKEN"}
+                       {"comma": ",", "(period | dot)": ".", "(pair | parentheses)": "(~)",
+                        "[square] (bracket | brackets)": "[~]", "curly [brace]": "{~}",
+                        "loop": "for~while", "L paren": "(", "are paren": ")", "openers": "(~[~{",
+                        "closers": "}~]~)", "token": "TOKEN"}
                        )
-
 
 
 def get_direction_choice(name):
     global DIRECTION_STANDARD
     return Choice(name, DIRECTION_STANDARD)
 
+
 def initialize_clipboard(nexus):
     if len(nexus.clip) == 0:
-        nexus.clip = utilities.load_json_file(settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
+        nexus.clip = utilities.load_json_file(
+            settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
+
 
 def mouse_alternates(mode, nexus, monitor=1):
     if nexus.dep.PIL:
         if mode == "legion" and not utilities.window_exists(None, "legiongrid"):
-            r = monitors[int(monitor)-1].rectangle
-            bbox = [int(r.x), int(r.y), int(r.x) + int(r.dx) - 1, int(r.y) + int(r.dy) - 1]
+            r = monitors[int(monitor) - 1].rectangle
+            bbox = [int(r.x), int(r.y), int(r.x) +
+                    int(r.dx) - 1, int(r.y) + int(r.dy) - 1]
             ls = LegionScanner()
             ls.scan(bbox)
             tscan = ls.get_update()
-            Popen(["pythonw", settings.SETTINGS["paths"]["LEGION_PATH"], "-t", tscan[0], "-m", str(monitor)])#, "-d", "500_500_500_500"
+            Popen(["pythonw", settings.SETTINGS["paths"]["LEGION_PATH"], "-t",
+                   tscan[0], "-m", str(monitor)])  # , "-d", "500_500_500_500"
         elif mode == "rainbow" and not utilities.window_exists(None, "rainbowgrid"):
-            Popen(["pythonw", settings.SETTINGS["paths"]["RAINBOW_PATH"], "-g", "r", "-m", str(monitor)])
+            Popen(["pythonw", settings.SETTINGS["paths"]
+                   ["RAINBOW_PATH"], "-g", "r", "-m", str(monitor)])
         elif mode == "douglas" and not utilities.window_exists(None, "douglasgrid"):
-            Popen(["pythonw", settings.SETTINGS["paths"]["DOUGLAS_PATH"], "-g", "d", "-m", str(monitor)])
+            Popen(["pythonw", settings.SETTINGS["paths"]
+                   ["DOUGLAS_PATH"], "-g", "d", "-m", str(monitor)])
     else:
-        utilities.availability_message(mode.title(), "PIL")    
+        utilities.availability_message(mode.title(), "PIL")
 
 
 def clipboard_to_file(nnavi500, nexus, do_copy=False):
     if do_copy:
         Key("c-c").execute()
-    
+
     max_tries = 20
-    
+
     key = str(nnavi500)
     for i in range(0, max_tries):
         failure = False
         try:
-            time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)   # time for keypress to execute
-            win32clipboard.OpenClipboard()
-            nexus.clip[key] = win32clipboard.GetClipboardData()
-            win32clipboard.CloseClipboard()
-            utilities.save_json_file(nexus.clip, settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])            
+            # time for keypress to execute
+            time.sleep(
+                 settings.SETTINGS["miscellaneous"]["keypress_wait"] / 1000.)
+            OpenClipboard()
+            fmt = GetPriorityClipboardFormat(
+                (CF_UNICODETEXT, CF_TEXT))
+            if fmt > 0:
+                nexus.clip[key] = GetClipboardData(fmt)
+            CloseClipboard()
+            utilities.save_json_file(
+                nexus.clip, settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
         except Exception:
             failure = True
             utilities.simple_log()
         if not failure:
             break
+
 
 def drop(nnavi500, nexus):
     key = str(nnavi500)
@@ -81,26 +96,31 @@ def drop(nnavi500, nexus):
         failure = False
         try:
             if key in nexus.clip:
-                win32clipboard.OpenClipboard()
-                win32clipboard.EmptyClipboard()
-                win32clipboard.SetClipboardText(nexus.clip[key])
-                win32clipboard.CloseClipboard()
+                OpenClipboard()
+                EmptyClipboard()
+                SetClipboardText(nexus.clip[key])
+                CloseClipboard()
                 Key("c-v").execute()
             else:
                 dragonfly.get_engine().speak("slot empty")
-            time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.) 
+            time.sleep(
+                settings.SETTINGS["miscellaneous"]["keypress_wait"] / 1000.)
         except Exception:
             failure = True
         if not failure:
             break
 
+
 def erase_multi_clipboard(nexus):
     nexus.clip = {}
-    utilities.save_json_file(nexus.clip, settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
+    utilities.save_json_file(
+        nexus.clip, settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
+
 
 def volume_control(n, volume_mode):
     for i in range(0, int(n)):
         Key("volume" + str(volume_mode)).execute()
+
 
 def kill_grids_and_wait(nexus):
     window_title = utilities.get_active_window_title()
@@ -108,29 +128,34 @@ def kill_grids_and_wait(nexus):
         nexus.comm.get_com("grids").kill()
         time.sleep(0.1)
 
+
 def kick(nexus):
     kill_grids_and_wait(nexus)
     windll.user32.mouse_event(0x00000002, 0, 0, 0, 0)
     windll.user32.mouse_event(0x00000004, 0, 0, 0, 0)
+
 
 def kick_right(nexus):
     kill_grids_and_wait(nexus)
     windll.user32.mouse_event(0x00000008, 0, 0, 0, 0)
     windll.user32.mouse_event(0x00000010, 0, 0, 0, 0)
 
+
 def kick_middle(nexus):
     kill_grids_and_wait(nexus)
     windll.user32.mouse_event(0x00000020, 0, 0, 0, 0)
     windll.user32.mouse_event(0x00000040, 0, 0, 0, 0)
 
+
 def wheel_scroll(direction, nnavi500):
     amount = 120
     if direction != "up":
-        amount = amount * -1;
-    for i in xrange(1, abs(nnavi500)+1):
+        amount = amount * -1
+    for i in xrange(1, abs(nnavi500) + 1):
         windll.user32.mouse_event(0x00000800, 0, 0, amount, 0)
         time.sleep(0.1)
-    
+
+
 def curse(direction, direction2, nnavi500, dokick):
     x, y = 0, 0
     d = str(direction)
@@ -143,22 +168,20 @@ def curse(direction, direction2, nnavi500, dokick):
         x = -nnavi500
     if d == "right" or d2 == "right":
         x = nnavi500
-    
+
     Mouse("<" + str(x) + ", " + str(y) + ">").execute()
-    if int(dokick)!=0:
-        if int(dokick)==1:
+    if int(dokick) != 0:
+        if int(dokick) == 1:
             kick()
-        elif int(dokick)==2:
+        elif int(dokick) == 2:
             kick_right()
 
+
 def next_line(semi):
-    semi=str(semi)
+    semi = str(semi)
     Key("escape").execute()
     time.sleep(0.25)
     Key("end").execute()
     time.sleep(0.25)
     Text(semi).execute()
     Key("enter").execute()
-
-
-

--- a/caster/lib/navigation.py
+++ b/caster/lib/navigation.py
@@ -10,11 +10,7 @@ from subprocess import Popen
 import dragonfly
 from caster.asynch.mouse.legion import LegionScanner
 from caster.lib import settings, utilities
-from dragonfly import Choice, Key, Mouse, Text, monitors
-from win32clipboard import (CF_TEXT, CF_UNICODETEXT, CloseClipboard,
-                            EmptyClipboard, GetClipboardData,
-                            GetPriorityClipboardFormat, OpenClipboard,
-                            SetClipboardText)
+from dragonfly import Choice, Clipboard, Key, Mouse, Text, monitors
 
 DIRECTION_STANDARD = {
     "sauce [E]": "up",
@@ -99,11 +95,7 @@ def clipboard_to_file(nnavi500, nexus, do_copy=False):
         try:
             # time for keypress to execute
             time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"] / 1000.)
-            OpenClipboard()
-            fmt = GetPriorityClipboardFormat((CF_UNICODETEXT, CF_TEXT))
-            if fmt > 0:
-                nexus.clip[key] = GetClipboardData(fmt)
-            CloseClipboard()
+            nexus.clip[key] = Clipboard.get_system_text()
             utilities.save_json_file(nexus.clip,
                                      settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
         except Exception:
@@ -119,10 +111,7 @@ def drop(nnavi500, nexus):
         failure = False
         try:
             if key in nexus.clip:
-                OpenClipboard()
-                EmptyClipboard()
-                SetClipboardText(nexus.clip[key], CF_UNICODETEXT)
-                CloseClipboard()
+                Clipboard.set_system_text(nexus.clip[key])
                 Key("c-v").execute()
             else:
                 dragonfly.get_engine().speak("slot empty")

--- a/caster/lib/settings.py
+++ b/caster/lib/settings.py
@@ -1,10 +1,13 @@
+# -*- coding: utf-8 -*-
+
+import collections
+import io
 import json
 import os
 import sys
-import collections
 
 SETTINGS = {}
-_SETTINGS_PATH = os.path.realpath(__file__).split("lib")[0]+"bin\\data\\settings.json"
+_SETTINGS_PATH = os.path.realpath(__file__).split("lib")[0] + "bin\\data\\settings.json"
 BASE_PATH = os.path.realpath(__file__).split("\\lib")[0].replace("\\", "/")
 
 # title
@@ -31,6 +34,7 @@ HMC_SEPARATOR = "[hmc]"
 
 WSR = False
 
+
 def _find_natspeak():
     '''Tries to find the natspeak engine.'''
     possible_locations = [
@@ -45,7 +49,8 @@ def _find_natspeak():
     print "Cannot find default dragon engine path"
     return ""
 
-# The defaults for every setting. Could be moved out into its own file. 
+
+# The defaults for every setting. Could be moved out into its own file.
 _DEFAULT_SETTINGS = {
     "paths": {
         "BASE_PATH": BASE_PATH,
@@ -131,7 +136,7 @@ _DEFAULT_SETTINGS = {
     "miscellaneous": {
         "dev_commands": False,
         "sikuli_enabled": False,
-        "keypress_wait": 50, # milliseconds
+        "keypress_wait": 50,  # milliseconds
         "max_ccr_repetitions": 16,
         "atom_palette_wait": "30",
         "rdp_mode": False,
@@ -152,27 +157,25 @@ _DEFAULT_SETTINGS = {
 def _save(data, path):
     '''only to be used for settings file'''
     try:
-        formatted_data = json.dumps(data, sort_keys=True, indent=4, ensure_ascii=False)
-        if not os.path.exists(path):
-            f = open(path, "w")
-            f.close()
-        f = open(path, "w")
-        f.write(formatted_data)
-        f.close()
+        formatted_data = unicode(
+            json.dumps(data, sort_keys=True, indent=4, ensure_ascii=False))
+        with io.open(path, "wt", encoding="utf-8") as f:
+            f.write(formatted_data)
     except Exception:
         print "Error saving json file: " + path
+
 
 def _init(path):
     result = {}
     try:
-        f = open(path, "r")
-        result = json.loads(f.read())
-        f.close()
-    except ValueError:
-        print("\n\nValueError while loading settings file: " + path + "\n\n")
+        with io.open(path, "rt", encoding="utf-8") as f:
+            result = json.loads(f.read())
+    except ValueError as e:
+        print("\n\n" + repr(e) + " while loading settings file: " + path + "\n\n")
         print(sys.exc_info())
-    except IOError:
-        print("\n\nIOError: Could not find settings file: " + path + "\nInitializing file...\n\n")
+    except IOError as e:
+        print("\n\n" + repr(e) + " while loading settings file: " + path +
+              "\nAttempting to recover...\n\n")
     result, num_default_added = _deep_merge_defaults(result, _DEFAULT_SETTINGS)
     if num_default_added > 0:
         print "Default settings values added: %d " % num_default_added
@@ -189,8 +192,8 @@ def _deep_merge_defaults(data, defaults):
     changes = 0
     for key, default_value in defaults.iteritems():
         # If the key is in the data, use that, but call recursivly if it's a dict.
-        if(key in data):
-            if(isinstance(data[key], collections.Mapping)):
+        if (key in data):
+            if (isinstance(data[key], collections.Mapping)):
                 child_data, child_changes = _deep_merge_defaults(data[key], default_value)
                 data[key] = child_data
                 changes += child_changes
@@ -200,33 +203,33 @@ def _deep_merge_defaults(data, defaults):
     return data, changes
 
 
-
 # Public interface:
 def save_config():
     '''Save the current in-memory settings to disk'''
     _save(SETTINGS, _SETTINGS_PATH)
 
+
 def get_settings():
     global SETTINGS
     return SETTINGS
+
 
 def get_default_browser_executable():
     global SETTINGS
     return SETTINGS["paths"]["DEFAULT_BROWSER_PATH"].split("/")[-1]
 
+
 def report_to_file(message, path=None):
     _path = SETTINGS["paths"]["LOG_PATH"]
     if path is not None: _path = path
-    f = open(_path, 'a')
-    f.write(str(message) + "\n")
-    f.close()
+    with io.open(_path, 'at', encoding="utf-8") as f:
+        f.write(unicode(message) + "\n")
 
 
 ## Kick everything off.
 SETTINGS = _init(_SETTINGS_PATH)
 for path in [
-        SETTINGS["paths"]["REMOTE_DEBUGGER_PATH"],
-        SETTINGS["paths"]["WXPYTHON_PATH"]
-    ]:
+        SETTINGS["paths"]["REMOTE_DEBUGGER_PATH"], SETTINGS["paths"]["WXPYTHON_PATH"]
+]:
     if not path in sys.path and os.path.isdir(path):
         sys.path.append(path)

--- a/caster/lib/utilities.py
+++ b/caster/lib/utilities.py
@@ -1,18 +1,23 @@
 # -*- coding: utf-8 -*-
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
 
-import os, json, sys
+import os
+import json
+import sys
 import re
 from subprocess import Popen
 import traceback
+import codecs
 
 from dragonfly.windows.window import Window
-import win32gui, win32ui
+import win32gui
+import win32ui
 from __builtin__ import True
 
 
-try: # Style C -- may be imported into Caster, or externally
-    BASE_PATH = os.path.realpath(__file__).split("\\caster")[0].replace("\\", "/")
+try:  # Style C -- may be imported into Caster, or externally
+    BASE_PATH = os.path.realpath(__file__).split("\\caster")[
+        0].replace("\\", "/")
     if BASE_PATH not in sys.path:
         sys.path.append(BASE_PATH)
 finally:
@@ -20,6 +25,7 @@ finally:
 
 # filename_pattern was used to determine when to update the list in the element window, checked to see when a new file name had appeared
 FILENAME_PATTERN = re.compile(r"[/\\]([\w_ ]+\.[\w]+)")
+
 
 def window_exists(classname, windowname):
     try:
@@ -29,17 +35,21 @@ def window_exists(classname, windowname):
     else:
         return True
 
+
 def get_active_window_title(pid=None):
-    _pid=win32gui.GetForegroundWindow() if pid is None else pid
+    _pid = win32gui.GetForegroundWindow() if pid is None else pid
     return unicode(win32gui.GetWindowText(_pid), errors='ignore')
+
 
 def get_active_window_path():
     return Window.get_foreground().executable
+
 
 def get_window_by_title(title):
     # returns 0 if nothing found
     hwnd = win32gui.FindWindowEx(0, 0, 0, title)
     return hwnd
+
 
 def get_window_title_info():
     '''get name of active file and folders in path;
@@ -49,11 +59,10 @@ def get_window_title_info():
     title = get_active_window_title().replace("\\", "/")
     match_object = FILENAME_PATTERN.findall(title)
     filename = None
-    if len(match_object) > 0:  
+    if len(match_object) > 0:
         filename = match_object[0]
     path_folders = title.split("/")[:-1]
     return [filename, path_folders, title]
-    
 
 
 # begin stuff that was moved
@@ -61,22 +70,22 @@ def get_window_title_info():
 def save_json_file(data, path):
     try:
         formatted_data = json.dumps(data, sort_keys=True, indent=4,
-            ensure_ascii=False)
-        if not os.path.exists(path):
-            f = open(path, "w")
-            f.close()
-        with open(path, "w") as f:
+                                    ensure_ascii=False, encoding="utf-8")
+        # if not os.path.exists(path):
+        #     f = open(path, "w")
+        #     f.close()
+        with codecs.open(path, "w", encoding="utf-8") as f:
             f.write(formatted_data)
     except Exception:
         simple_log(True)
+
 
 def load_json_file(path):
     result = {}
     try:
         if os.path.isfile(path):  # If the file exists.
-            with open(path, "r") as f:
-                result = json.loads(f.read())
-                f.close()
+            with codecs.open(path, "r", encoding="utf-8") as f:
+                result = json.loads(f.read().replace("\r", ""))
         else:
             save_json_file(result, path)
     except Exception:
@@ -85,44 +94,46 @@ def load_json_file(path):
 
 
 def list_to_string(l):
-    return "\n".join([str(x) for x in l])
-            
+    return u"\n".join([unicode(x) for x in l])
+
+
 def simple_log(to_file=False):
     msg = list_to_string(sys.exc_info())
     print(msg)
     for tb in traceback.format_tb(sys.exc_info()[2]):
-        print(tb)
+        print (tb)
     if to_file:
-        f = open(settings.SETTINGS["paths"]["LOG_PATH"], 'a') 
-        f.write(msg + "\n")
-        f.close()
-
+        with codecs.open(
+                settings.SETTINGS["paths"]["LOG_PATH"], 'a', encoding="utf-8") as f:
+            f.write(msg + "\n")
 
 
 def availability_message(feature, dependency):
     print(feature + " feature not available without " + dependency)
 
 # end stuff that was moved
+
+
 def remote_debug(who_called_it=None):
-    import pydevd;  # @UnresolvedImport
     if who_called_it is None:
         who_called_it = "An unidentified process"
     try:
+        import pydevd  # @UnresolvedImport
         pydevd.settrace()
     except Exception:
-        print("ERROR: " + who_called_it + " called utilities.remote_debug() but the debug server wasn't running.")
-    
+        print("ERROR: " + who_called_it +
+              " called utilities.remote_debug() but the debug server wasn't running.")
+
+
 def reboot(wsr=False):
     popen_parameters = []
     if wsr:
         popen_parameters.append(settings.SETTINGS["paths"]["REBOOT_PATH_WSR"])
         popen_parameters.append(settings.SETTINGS["paths"]["WSR_PATH"])
-        #caster path inserted too if there's a way to wake up WSR
+        # caster path inserted too if there's a way to wake up WSR
     else:
         popen_parameters.append(settings.SETTINGS["paths"]["REBOOT_PATH"])
         popen_parameters.append(settings.SETTINGS["paths"]["ENGINE_PATH"])
-        
+
     print(popen_parameters)
     Popen(popen_parameters)
-
-


### PR DESCRIPTION
This attempts to fix some long-standing issues with the way Caster interacts with the clipboard and reorganizes file I/O to be forwards compatible with Python 3. The files were reformatted through [YAPF](https://github.com/google/yapf) using the attached configuration file. I'm open to different styles and I will try to keep the style changes to a single commit in the future.
[style.txt](https://github.com/synkarius/caster/files/1823011/style.txt)

This patch changes Caster to prefer Unicode when interacting with the Windows clipboard. No attempts are made to explicitly handle legacy text localization. My hope is that Windows will do the right thing when it handles auto conversion. To support this, file I/O has been rewritten to assume and encode for UTF-8 in a way that is compatible with Python 3.

**I need help testing this.** The change was seamless for me, but all my configuration files were already 100% ASCII. **Backup your configuration files before testing this.**