### PR TITLE
Reimplementation methods to find DNS path via the registry

### DIFF
--- a/caster/bin/inno/dependencies/pip.bat
+++ b/caster/bin/inno/dependencies/pip.bat
@@ -1,5 +1,5 @@
 @echo off
-echo Installing: pywin32, dragonfly, pillow, psutil, wmi
+echo Installing: pywin32, dragonfly, pillow, psutil
 
 cd c:\python27\scripts
 pip install pywin32
@@ -7,7 +7,6 @@ pip install wxpython
 pip install dragonfly
 pip install pillow
 pip install psutil
-pip install wmi
 
 echo ------------------------------------------
 echo Caster Dependencies Installation Complete

--- a/caster/lib/settings.py
+++ b/caster/lib/settings.py
@@ -37,31 +37,32 @@ HMC_SEPARATOR = "[hmc]"
 WSR = False
 
 
-def _validate_engine_path():  # Validates 'Engine Path' in settings.json
+# Validates 'Engine Path' in settings.json
+def _validate_engine_path():
     if os.path.isfile(_SETTINGS_PATH):
         with io.open(_SETTINGS_PATH, "rt", encoding="utf-8") as json_file:
             data = json.loads(json_file.read())
-            exe_path = data["paths"]["ENGINE_PATH"]
-            if os.path.isfile(exe_path):
-                return exe_path
+            engine_path = data["paths"]["ENGINE_PATH"]
+            if os.path.isfile(engine_path):
+                return engine_path
             else:
-                exe_path = _find_natspeak()
-                data["paths"]["ENGINE_PATH"] = exe_path
+                engine_path = _find_natspeak()
+                data["paths"]["ENGINE_PATH"] = engine_path
                 try:
                     formatted_data = unicode(
                         json.dumps(data, sort_keys=True, indent=4, ensure_ascii=False))
                     with io.open(_SETTINGS_PATH, "w", encoding="utf-8") as json_file:
                         json_file.write(formatted_data)
-                        print "Setting engine path to " + exe_path
+                        print "Setting engine path to " + engine_path
                 except Exception as e:
-                    print "Error saving json file " + str(e) + _SETTINGS_PATH
-                return exe_path
+                    print "Error saving settings file " + str(e) + _SETTINGS_PATH
+                return engine_path
     else:
         return _find_natspeak()
 
 
-def _find_natspeak(
-):  # Finds DNS path and verifies supported DNS versions via Windows Registry.
+# Finds engine 'natspeak.exe' path and verifies supported DNS versions via Windows Registry.
+def _find_natspeak():
     print "Searching Windows Registry For DNS..."
     proc_arch = os.environ['PROCESSOR_ARCHITECTURE'].lower()
     proc_arch64 = os.environ['PROCESSOR_ARCHITEW6432'].lower()
@@ -91,16 +92,16 @@ def _find_natspeak(
             finally:
                 skey.Close()
                 if Publisher == "Nuance Communications Inc." and "Dragon" in DisplayName:
-                    DisplayVersion = int(str(DisplayVersion)[:2])
-                    if DisplayVersion >= 13:
-                        exe_path = InstallLocation.replace("\\",
-                                                           "/") + "Program/natspeak.exe"
-                        if os.path.isfile(exe_path):
+                    DnsVersion = int(str(DisplayVersion)[:2])
+                    if DnsVersion >= 13:
+                        engine_path = InstallLocation.replace(
+                            "\\", "/") + "Program/natspeak.exe"
+                        if os.path.isfile(engine_path):
                             print "Search Complete."
-                            return exe_path
+                            return engine_path
                     else:
                         print " Dragon Naturally Speaking " + str(
-                            DisplayVersion
+                            DnsVersion
                         ) + " is not supported by Caster. Only versions 13 and above are supported. Purchase Dragon Naturally Speaking 13 or above"
     print "Cannot find dragon engine path"
     return ""

--- a/caster/lib/settings.py
+++ b/caster/lib/settings.py
@@ -5,7 +5,8 @@ import io
 import json
 import os
 import sys
-import wmi
+import errno
+import _winreg
 
 SETTINGS = {}
 _SETTINGS_PATH = os.path.realpath(__file__).split("lib")[0] + "bin\\data\\settings.json"
@@ -36,7 +37,7 @@ HMC_SEPARATOR = "[hmc]"
 WSR = False
 
 
-def _validate_natspeak():  # Validates 'Engine Path' for DNS in settings.json
+def _validate_engine_path():  # Validates 'Engine Path' in settings.json
     if os.path.isfile(_SETTINGS_PATH):
         with io.open(_SETTINGS_PATH, "rt", encoding="utf-8") as json_file:
             data = json.loads(json_file.read())
@@ -51,7 +52,7 @@ def _validate_natspeak():  # Validates 'Engine Path' for DNS in settings.json
                         json.dumps(data, sort_keys=True, indent=4, ensure_ascii=False))
                     with io.open(_SETTINGS_PATH, "w", encoding="utf-8") as json_file:
                         json_file.write(formatted_data)
-                        print "Setting DNS path to " + exe_path
+                        print "Setting engine path to " + exe_path
                 except Exception as e:
                     print "Error saving json file " + str(e) + _SETTINGS_PATH
                 return exe_path
@@ -61,29 +62,43 @@ def _validate_natspeak():  # Validates 'Engine Path' for DNS in settings.json
 
 def _find_natspeak():  # Finds DNS path and verifies supported DNS versions via Windows Registry.
     print "Searching Windows Registry For DNS..."
-    w = wmi.WMI()
-    for p in w.Win32_Product():
-        if p.Caption and "Dragon" in p.Caption:
-            name = "{}".format(p.Name)
-            version = "{}".format(p.Version)
-            vendor = "{}".format(p.Vendor)
-            install_location = "{}".format(p.InstallLocation)
+    proc_arch = os.environ['PROCESSOR_ARCHITECTURE'].lower()
+    proc_arch64 = os.environ['PROCESSOR_ARCHITEW6432'].lower()
 
-            if vendor == "Nuance Communications Inc." and name == "Dragon":
-                dns_version = int(str(version)[:2])
-                if dns_version >= 13:
-                    exe_path = install_location.replace("\\",
-                                                        "/") + "Program/natspeak.exe"
-                    if os.path.isfile(exe_path):
-                        print "Search Complete."
-                        return exe_path
-                else:
-                    print " Dragon Naturally Speaking" + str(
-                        version
-                    ) + " is not supported by Caster. Only versions 13 and above are supported. Purchase Dragon Naturally Speaking 13 or above"
+    if proc_arch == 'x86' and not proc_arch64:
+        arch_keys = {0}
+    elif proc_arch == 'x86' or proc_arch == 'amd64':
+        arch_keys = {_winreg.KEY_WOW64_32KEY, _winreg.KEY_WOW64_64KEY}
+    else:
+        raise Exception("Unhandled arch: %s" % proc_arch)
+
+    for arch_key in arch_keys:
+        key = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall", 0, _winreg.KEY_READ | arch_key)
+        for i in xrange(0, _winreg.QueryInfoKey(key)[0]):
+            skey_name = _winreg.EnumKey(key, i)
+            skey = _winreg.OpenKey(key, skey_name)
+            try:
+                DisplayName = _winreg.QueryValueEx(skey, 'DisplayName')[0]
+                Publisher = _winreg.QueryValueEx(skey, 'Publisher')[0]
+                DisplayVersion = _winreg.QueryValueEx(skey, 'DisplayVersion')[0]
+                InstallLocation = _winreg.QueryValueEx(skey, 'InstallLocation')[0]
+            except OSError as e:
+                if e.errno == errno.ENOENT:
+                    pass
+            finally:
+                skey.Close()
+                if Publisher == "Nuance Communications Inc." and "Dragon" in DisplayName:
+                    DisplayVersion = int(str(DisplayVersion)[:2])
+                    if DisplayVersion >= 13:
+                        exe_path = InstallLocation.replace("\\",
+                                                            "/") + "Program/natspeak.exe"
+                        if os.path.isfile(exe_path):
+                            print "Search Complete."
+                            return exe_path
+                    else:
+                        print " Dragon Naturally Speaking " + str(DisplayVersion) + " is not supported by Caster. Only versions 13 and above are supported. Purchase Dragon Naturally Speaking 13 or above"
     print "Cannot find dragon engine path"
     return ""
-
 
 # The defaults for every setting. Could be moved out into its own file.
 _DEFAULT_SETTINGS = {
@@ -106,7 +121,7 @@ _DEFAULT_SETTINGS = {
         # EXECUTABLES
         "DEFAULT_BROWSER_PATH": "C:/Program Files (x86)/Mozilla Firefox/firefox.exe",
         "DOUGLAS_PATH": BASE_PATH + "/asynch/mouse/grids.py",
-        "ENGINE_PATH": _validate_natspeak(),
+        "ENGINE_PATH": _validate_engine_path(),
         "HOMUNCULUS_PATH": BASE_PATH + "/asynch/hmc/h_launch.py",
         "LEGION_PATH": BASE_PATH + "/asynch/mouse/legion.py",
         "MEDIA_PATH": BASE_PATH + "/bin/media",

--- a/caster/lib/settings.py
+++ b/caster/lib/settings.py
@@ -81,14 +81,17 @@ def _find_natspeak():
         for i in xrange(0, _winreg.QueryInfoKey(key)[0]):
             skey_name = _winreg.EnumKey(key, i)
             skey = _winreg.OpenKey(key, skey_name)
+            DisplayName, Publisher, DisplayVersion, InstallLocation = 'null'
             try:
                 DisplayName = _winreg.QueryValueEx(skey, 'DisplayName')[0]
                 Publisher = _winreg.QueryValueEx(skey, 'Publisher')[0]
                 DisplayVersion = _winreg.QueryValueEx(skey, 'DisplayVersion')[0]
                 InstallLocation = _winreg.QueryValueEx(skey, 'InstallLocation')[0]
-            except OSError as e:
-                if e.errno == errno.ENOENT:
+            except OSError as error:
+                if error.errno == 2:  # Suppresses '[Error 2] The system cannot find the file specified'
                     pass
+                else:
+                    print error
             finally:
                 skey.Close()
                 if Publisher == "Nuance Communications Inc." and "Dragon" in DisplayName:

--- a/caster/lib/settings.py
+++ b/caster/lib/settings.py
@@ -60,7 +60,8 @@ def _validate_engine_path():  # Validates 'Engine Path' in settings.json
         return _find_natspeak()
 
 
-def _find_natspeak():  # Finds DNS path and verifies supported DNS versions via Windows Registry.
+def _find_natspeak(
+):  # Finds DNS path and verifies supported DNS versions via Windows Registry.
     print "Searching Windows Registry For DNS..."
     proc_arch = os.environ['PROCESSOR_ARCHITECTURE'].lower()
     proc_arch64 = os.environ['PROCESSOR_ARCHITEW6432'].lower()
@@ -73,7 +74,9 @@ def _find_natspeak():  # Finds DNS path and verifies supported DNS versions via 
         raise Exception("Unhandled arch: %s" % proc_arch)
 
     for arch_key in arch_keys:
-        key = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall", 0, _winreg.KEY_READ | arch_key)
+        key = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE,
+                              r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall", 0,
+                              _winreg.KEY_READ | arch_key)
         for i in xrange(0, _winreg.QueryInfoKey(key)[0]):
             skey_name = _winreg.EnumKey(key, i)
             skey = _winreg.OpenKey(key, skey_name)
@@ -91,14 +94,17 @@ def _find_natspeak():  # Finds DNS path and verifies supported DNS versions via 
                     DisplayVersion = int(str(DisplayVersion)[:2])
                     if DisplayVersion >= 13:
                         exe_path = InstallLocation.replace("\\",
-                                                            "/") + "Program/natspeak.exe"
+                                                           "/") + "Program/natspeak.exe"
                         if os.path.isfile(exe_path):
                             print "Search Complete."
                             return exe_path
                     else:
-                        print " Dragon Naturally Speaking " + str(DisplayVersion) + " is not supported by Caster. Only versions 13 and above are supported. Purchase Dragon Naturally Speaking 13 or above"
+                        print " Dragon Naturally Speaking " + str(
+                            DisplayVersion
+                        ) + " is not supported by Caster. Only versions 13 and above are supported. Purchase Dragon Naturally Speaking 13 or above"
     print "Cannot find dragon engine path"
     return ""
+
 
 # The defaults for every setting. Could be moved out into its own file.
 _DEFAULT_SETTINGS = {


### PR DESCRIPTION
Do to issues #248 with Win32_Product and wmi I have re-implemented #242 #243 methods to find DNS path via the registry.

 Overview of changes
- Does not rely on Win32_Product() from Wmi
- Wmi dependence removed for _winreg
- Renamed _validate_natspeak() to _validate_engine_path() as its engine agnostic
- Renamed exe_path to engine_path for clarity
- Renamed DisplayVersion to DnsVersion for clarity as needed
- Edited comments for clarity