### PR TITLE
Stoosh spark update – needs testing

### DIFF
--- a/caster/lib/ccr/core/nav.py
+++ b/caster/lib/ccr/core/nav.py
@@ -74,11 +74,12 @@ class NavigationNon(MappingRule):
             R(Key("control:down") + Mouse("left") + Key("control:up"),
               rdescript="Mouse: Ctrl + Left Click"),
         "garb [<nnavi500>]":
-            R(Mouse("left") + Mouse("left") + Key("c-c") +
-              Function(navigation.clipboard_to_file, nexus=_NEXUS),
+            R(Mouse("left") + Mouse("left") + Function(
+                navigation.stoosh_keep_clipboard, nexus=_NEXUS),
               rdescript="Highlight @ Mouse + Copy"),
         "drop [<nnavi500>]":
-            R(Mouse("left") + Mouse("left") + Function(navigation.drop, nexus=_NEXUS),
+            R(Mouse("left") + Mouse("left") + Function(
+                navigation.drop_keep_clipboard, nexus=_NEXUS),
               rdescript="Highlight @ Mouse + Paste"),
         "sure stoosh":
             R(Key("c-c"), rdescript="Simple Copy"),
@@ -185,9 +186,9 @@ class Navigation(MergeRule):
 
     "(<mtn_dir> | <mtn_mode> [<mtn_dir>]) [(<nnavi500> | <extreme>)]": R(Function(textformat.master_text_nav), rdescript="Keyboard Text Navigation"),
 
-    "stoosh [<nnavi500>]":          R(Key("c-c")+Function(navigation.clipboard_to_file, nexus=_NEXUS), rspec="stoosh", rdescript="Copy"),
-    "cut [<nnavi500>]":             R(Key("c-x")+Function(navigation.clipboard_to_file, nexus=_NEXUS), rspec="cut", rdescript="Cut"),
-    "spark [<nnavi500>]":           R(Function(navigation.drop, nexus=_NEXUS), rspec="spark", rdescript="Paste"),
+    "stoosh [<nnavi500>]":          R(Function(navigation.stoosh_keep_clipboard, nexus=_NEXUS), rspec="stoosh", rdescript="Copy"),
+    "cut [<nnavi500>]":             R(Function(navigation.cut_keep_clipboard, nexus=_NEXUS), rspec="cut", rdescript="Cut"),
+    "spark [<nnavi500>]":           R(Function(navigation.drop_keep_clipboard, nexus=_NEXUS), rspec="spark", rdescript="Paste"),
 
     "deli [<nnavi50>]":             R(Key("del/5"), rspec="deli", rdescript="Delete") * Repeat(extra="nnavi50"),
     "clear [<nnavi50>]":            R(Key("backspace/5:%(nnavi50)d"), rspec="clear", rdescript="Backspace"),
@@ -196,7 +197,7 @@ class Navigation(MergeRule):
 
     "shackle":                      R(Key("home/5, s-end"), rspec="shackle", rdescript="Select Line"),
     "(tell | tau) <semi>":          R(Function(navigation.next_line), rspec="tell dock", rdescript="Complete Line"),
-    "duple [<nnavi50>]":            R(Key("escape, home, s-end, c-c, end, enter, c-v"), rspec="duple", rdescript="Duplicate Line") * Repeat(extra="nnavi50"),
+    "duple [<nnavi50>]":            R(Function(navigation.duple_keep_clipboard), rspec="duple", rdescript="Duplicate Line"),
     "Kraken":                       R(Key("c-space"), rspec="Kraken", rdescript="Control Space"),
 
     # text formatting
@@ -212,17 +213,19 @@ class Navigation(MergeRule):
     }
 
     extras = [
+        IntegerRefST("nnavi10", 1, 11),
         IntegerRefST("nnavi50", 1, 50),
         IntegerRefST("nnavi500", 1, 500),
         Dictation("textnv"),
-        Choice("enclosure", {
-            "prekris": "(~)",
-            "angle": "<~>",
-            "curly": "{~}",
-            "brax": "[~]",
-            "thin quotes": "'~'",
-            'quotes': '"~"',
-        }),
+        Choice(
+            "enclosure", {
+                "prekris": "(~)",
+                "angle": "<~>",
+                "curly": "{~}",
+                "brax": "[~]",
+                "thin quotes": "'~'",
+                'quotes': '"~"',
+            }),
         Choice("capitalization", {
             "yell": 1,
             "tie": 2,
@@ -230,16 +233,17 @@ class Navigation(MergeRule):
             "sing": 4,
             "laws": 5
         }),
-        Choice("spacing", {
-            "gum": 1,
-            "gun": 1,
-            "spine": 2,
-            "snake": 3,
-            "pebble": 4,
-            "incline": 5,
-            "dissent": 6,
-            "descent": 6
-        }),
+        Choice(
+            "spacing", {
+                "gum": 1,
+                "gun": 1,
+                "spine": 2,
+                "snake": 3,
+                "pebble": 4,
+                "incline": 5,
+                "dissent": 6,
+                "descent": 6
+            }),
         Choice("semi", {
             "dock": ";",
             "doc": ";",
@@ -266,6 +270,7 @@ class Navigation(MergeRule):
     defaults = {
         "nnavi500": 1,
         "nnavi50": 1,
+        "nnavi10": 1,
         "textnv": "",
         "capitalization": 0,
         "spacing": 0,

--- a/caster/lib/navigation.py
+++ b/caster/lib/navigation.py
@@ -84,44 +84,81 @@ def mouse_alternates(mode, nexus, monitor=1):
     else:
         utilities.availability_message(mode.title(), "PIL")
 
-
-def clipboard_to_file(nnavi500, nexus, do_copy=False):
-    if do_copy:
+def stoosh_keep_clipboard(nnavi500, nexus):
+    if nnavi500 == 1:
         Key("c-c").execute()
+    else:
+        max_tries = 20
+        cb = Clipboard(from_system=True)
+        Key("c-c").execute()
+        key = str(nnavi500)
+        for i in range(0, max_tries):
+            failure = False
+            try:
+                # time for keypress to execute
+                time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
+                nexus.clip[key] = Clipboard.get_system_text()
+                utilities.save_json_file(nexus.clip,
+                                        settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
+            except Exception:
+                failure = True
+                utilities.simple_log()
+                if not failure:
+                    break
+        cb.copy_to_system()
 
-    max_tries = 20
+def cut_keep_clipboard(nnavi500, nexus):
+    if nnavi500 == 1:
+        Key("c-x").execute()
+    else:
+        max_tries = 20
+        cb = Clipboard(from_system=True)
+        Key("c-x").execute()
+        key = str(nnavi500)
+        for i in range(0, max_tries):
+            failure = False
+            try:
+                # time for keypress to execute
+                time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
+                nexus.clip[key] = Clipboard.get_system_text()
+                utilities.save_json_file(nexus.clip,
+                                        settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
+            except Exception:
+                failure = True
+                utilities.simple_log()
+                if not failure:
+                    break
+        cb.copy_to_system()
 
-    key = str(nnavi500)
-    for i in range(0, max_tries):
-        failure = False
-        try:
-            # time for keypress to execute
-            time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
-            nexus.clip[key] = Clipboard.get_system_text()
-            utilities.save_json_file(nexus.clip,
-                                     settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
-        except Exception:
-            failure = True
-            utilities.simple_log()
-        if not failure:
-            break
+def drop_keep_clipboard(nnavi500, nexus):
+    if nnavi500 == 1:
+        Key("c-v").execute()
+    else:
+        key = str(nnavi500)
+        cb = Clipboard(from_system=True)
+        while True:
+            failure = False
+            try:
+                if key in nexus.clip:
+                    Clipboard.set_system_text(nexus.clip[key])
+                    Key("c-v").execute()
+                else:
+                    dragonfly.get_engine().speak("slot empty")
+                time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
+            except Exception:
+                failure = True
+            if not failure:
+                break
+        cb.copy_to_system()
 
-
-def drop(nnavi500, nexus):
-    key = str(nnavi500)
-    while True:
-        failure = False
-        try:
-            if key in nexus.clip:
-                Clipboard.set_system_text(nexus.clip[key])
-                Key("c-v").execute()
-            else:
-                dragonfly.get_engine().speak("slot empty")
-            time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
-        except Exception:
-            failure = True
-        if not failure:
-            break
+def duple_keep_clipboard(nnavi50):
+    cb = Clipboard(from_system=True)
+    Key("escape, home, s-end, c-c, end").execute()
+    time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
+    for i in range(0, nnavi50):
+        Key("enter, c-v").execute()
+        time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
+    cb.copy_to_system()
 
 
 def erase_multi_clipboard(nexus):

--- a/caster/lib/navigation.py
+++ b/caster/lib/navigation.py
@@ -103,8 +103,8 @@ def stoosh_keep_clipboard(nnavi500, nexus):
             except Exception:
                 failure = True
                 utilities.simple_log()
-                if not failure:
-                    break
+            if not failure:
+                break
         cb.copy_to_system()
 
 def cut_keep_clipboard(nnavi500, nexus):
@@ -126,25 +126,26 @@ def cut_keep_clipboard(nnavi500, nexus):
             except Exception:
                 failure = True
                 utilities.simple_log()
-                if not failure:
-                    break
+            if not failure:
+                break
         cb.copy_to_system()
 
 def drop_keep_clipboard(nnavi500, nexus):
     if nnavi500 == 1:
         Key("c-v").execute()
     else:
+        max_tries = 20
         key = str(nnavi500)
         cb = Clipboard(from_system=True)
-        while True:
+        for i in range(0, max_tries):
             failure = False
             try:
                 if key in nexus.clip:
                     Clipboard.set_system_text(nexus.clip[key])
                     Key("c-v").execute()
+                    time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
                 else:
                     dragonfly.get_engine().speak("slot empty")
-                time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
             except Exception:
                 failure = True
             if not failure:


### PR DESCRIPTION
Previously, saying "duple" would copy the current line to the clipboard, make a new line and then paste. This works, but it replaces whatever is in the clipboard with the line you are duplicating, which can be annoying. This is fairly simply fixed by altering all commands which use the clipboard so that they save and restore the clipboard before and after operations.

Commands like "stoosh/spark five" and "duple" should now no longer replace the normal clipboard, provided what's in the clipboard is only a string. Now that this is done it should be fairly easy to implement the first part of #214. 

I've been playing around to get the timings right so that it is completely reliable, but it would be worthwhile someone else testing it to make sure it's working properly.