### PR TITLE
Updated Caster dependencies .bat files

### DIFF
--- a/caster/bin/inno/dependencies/Pip Install Dependencies.bat
+++ b/caster/bin/inno/dependencies/Pip Install Dependencies.bat
@@ -2,6 +2,7 @@
 echo Installing: dragonfly2, wxPython, pillow
 
 cd c:\python27\scripts
+pip install setuptools
 pip install dragonfly2
 pip install -U wxPython
 pip install pillow

--- a/caster/bin/inno/dependencies/Pip Install Dependencies.bat
+++ b/caster/bin/inno/dependencies/Pip Install Dependencies.bat
@@ -6,7 +6,7 @@ pip install setuptools
 pip install dragonfly2
 pip install -U wxPython
 pip install pillow
-
+pip install toml
 
 echo ------------------------------------------
 echo Caster Dependencies Installation Complete

--- a/caster/bin/inno/dependencies/Pip Uninstall Dependencies.bat
+++ b/caster/bin/inno/dependencies/Pip Uninstall Dependencies.bat
@@ -1,0 +1,20 @@
+@echo off
+echo Uninstall dragonfly2, wxPython, pillow, six, pyperclip, pillow, pywin32
+echo ####
+echo #### Warning! Only uninstall dependencies that are no longer used for all Python projects.
+echo ####
+
+cd c:\python27\scripts
+pip uninstall dragonfly2
+pip uninstall wxPython
+pip uninstall pillow
+pip uninstall six
+pip uninstall pyperclip
+pip uninstall pillow
+pip uninstall pywin32
+
+echo ------------------------------------------
+echo Caster Dependencies Uninstall Complete
+echo ------------------------------------------
+
+pause

--- a/caster/bin/inno/dependencies/Pip Uninstall Dependencies.bat
+++ b/caster/bin/inno/dependencies/Pip Uninstall Dependencies.bat
@@ -12,6 +12,7 @@ pip uninstall six
 pip uninstall pyperclip
 pip uninstall pillow
 pip uninstall pywin32
+pip uninstall toml
 
 echo ------------------------------------------
 echo Caster Dependencies Uninstall Complete

--- a/caster/bin/inno/dependencies/pip.bat
+++ b/caster/bin/inno/dependencies/pip.bat
@@ -1,12 +1,11 @@
 @echo off
-echo Installing: pywin32, dragonfly, pillow, psutil
+echo Installing: dragonfly2, wxPython, pillow
 
 cd c:\python27\scripts
-pip install pywin32
-pip install wxpython
-pip install dragonfly
+pip install dragonfly2
+pip install -U wxPython
 pip install pillow
-pip install psutil
+
 
 echo ------------------------------------------
 echo Caster Dependencies Installation Complete


### PR DESCRIPTION
Updated to [dragonfly2 ](https://github.com/Danesprite/dragonfly) distribution 
- Removed unnecessary dependencies that are installed by the dragonfly community fork
- Removed psutil no longer relevant to Caster
- Added Uninstall Script 'Pip Uninstall Dependencies.bat'
- Renamed Pip.bat' to 'Pip Install Dependencies.bat'
- Add toml dependency.

**Reference**
Simplify Caster install #217 
Caster as a package #246 