### PR TITLE
Reworked CodeBase to reflect simplified alias command. 

### DIFF
--- a/_caster.py
+++ b/_caster.py
@@ -49,7 +49,7 @@ from caster.lib.dfplus.additions import IntegerRefST
 from caster.lib.dfplus.merge.mergepair import MergeInf
 from caster.lib.ccr import *
 from caster.lib.ccr.recording.again import Again
-from caster.lib.ccr.recording.alias import VanillaAlias
+from caster.lib.ccr.recording.alias import Alias
 from caster.lib.ccr.recording import history
 from caster.lib.dev import dev
 from caster.lib.dfplus.hint.nodes import css
@@ -153,7 +153,7 @@ if settings.SETTINGS["feature_rules"]["again"]:
     grammar.add_rule(again_rule)
 
 if settings.SETTINGS["feature_rules"]["alias"]:
-    alias_rule = VanillaAlias(name="vanilla alias")
+    alias_rule = Alias(name="alias")
     gfilter.run_on(alias_rule)
     grammar.add_rule(alias_rule)
 

--- a/caster/doc/readthedocs/Alias.MD
+++ b/caster/doc/readthedocs/Alias.MD
@@ -5,14 +5,14 @@ You can create commands on-the-fly by highlighting text on the screen and saying
 
 `"alias <something>"`
 
-With the vanilla version of the `alias` command, `<something>` is the spec of the new command you would like to create. For instance, if I highlight the word "create" in the previous sentence, then say "alias tiger", then after that, if I say the word "tiger", then the word "create" will be printed.
+With the `alias` command, `<something>` is the spec of the new command you would like to create. For instance, if I highlight the word "create" in the previous sentence, then say "alias tiger", then after that, if I say the word "tiger", then the word "create" will be printed.
 
 `chain alias`
 
 There are two differences with the `chain` version of the `alias` command. The first is that you don't have to speak the spec. A box will pop up and ask you for it. The second is that commands created with the `chain` version will be incorporated into the active CCR set, meaning, they'll be chainable with the other active CCR commands.
 
 ## Deleting Them
-You can delete alias commands either by editing your "configaliases.txt" file manually, or by simply saying "delete aliases". Doing the latter will wipe out both vanilla and chain aliases.
+You can delete alias commands either by editing your "configaliases.txt" file manually, or by simply saying "delete aliases". Doing the latter will wipe out both alias and chain aliases.
 
 ## Enabling Them
 Aliases are not enabled by default. After creating your first alias command, you'll have to say "enable aliases". Aliases are a CCR module, and work like the rest of the CCR modules in this regard.

--- a/caster/doc/readthedocs/CCR.MD
+++ b/caster/doc/readthedocs/CCR.MD
@@ -31,7 +31,7 @@ There are different kinds of Dragonfly and Caster rules which can be created or 
 
 * **Rule, CompoundRule, MappingRule**: the original Dragonfly rule types. These can be used with Caster, but not for CCR.
 * **MergeRule**: the basic Caster CCR building block. It is similar to Dragonfly's MappingRule, but has a few extra properties.
-* **SelfModifyingRule**: this is a type of MergeRule which modifies its own command set based on some kind of user input. NodeRule, VanillaAlias, ChainAlias, and HistoryRule are all SelfModifyingRules.
+* **SelfModifyingRule**: this is a type of MergeRule which modifies its own command set based on some kind of user input. NodeRule, Alias, ChainAlias, and HistoryRule are all SelfModifyingRules.
 
 We'll go into more detail on the differences between these rules elsewhere. For now, know that most rules used for CCR in Caster extend MergeRule.
 

--- a/caster/lib/ccr/recording/alias.py
+++ b/caster/lib/ccr/recording/alias.py
@@ -26,12 +26,12 @@ def delete_all(alias, path):
     alias.refresh()
 
 
-class VanillaAlias(SelfModifyingRule):
-    mapping = {"default vanilla command": NullAction()}
+class Alias(SelfModifyingRule):
+    mapping = {"default command": NullAction()}
     json_path = "single_aliases"
-    pronunciation = "vanilla alias"
+    pronunciation = "alias"
 
-    def vanilla_alias(self, spec):
+    def alias(self, spec):
         spec = str(spec)
         if spec != "":
             text = read_highlighted(10)
@@ -40,21 +40,21 @@ class VanillaAlias(SelfModifyingRule):
     def refresh(self, *args):
         '''args: spec, text'''
         aliases = utilities.load_json_file(settings.SETTINGS["paths"]["ALIAS_PATH"])
-        if not VanillaAlias.json_path in aliases:
-            aliases[VanillaAlias.json_path] = {}
+        if not Alias.json_path in aliases:
+            aliases[Alias.json_path] = {}
         if len(args) > 0:
-            aliases[VanillaAlias.json_path][args[0]] = args[1]
+            aliases[Alias.json_path][args[0]] = args[1]
             utilities.save_json_file(aliases, settings.SETTINGS["paths"]["ALIAS_PATH"])
         mapping = {}
-        for spec in aliases[VanillaAlias.json_path]:
+        for spec in aliases[Alias.json_path]:
             mapping[spec] = R(
-                Text(str(aliases[VanillaAlias.json_path][spec])),
+                Text(str(aliases[Alias.json_path][spec])),
                 rdescript="Alias: " + spec)
         mapping["alias <s>"] = R(
-            Function(lambda s: self.vanilla_alias(s)), rdescript="Create Vanilla Alias")
-        mapping["delete vanilla aliases"] = R(
-            Function(lambda: delete_all(self, VanillaAlias.json_path)),
-            rdescript="Delete Vanilla Aliases")
+            Function(lambda s: self.alias(s)), rdescript="Create Alias")
+        mapping["delete aliases"] = R(
+            Function(lambda: delete_all(self, Alias.json_path)),
+            rdescript="Delete Aliases")
         self.reset(mapping)
 
 
@@ -95,11 +95,11 @@ class ChainAlias(SelfModifyingRule):
             Function(self.chain_alias), rdescript="Create Chainable Alias")
         mapping["delete chain aliases"] = R(
             Function(lambda: delete_all(self, ChainAlias.json_path)),
-            rdescript="Delete Vanilla Aliases")
+            rdescript="Delete Aliases")
         self.reset(mapping)
 
-
+if settings.SETTINGS["feature_rules"]["alias"]:
+    control.nexus().merger.add_selfmodrule(Alias())
 if settings.SETTINGS["feature_rules"]["chainalias"]:
     control.nexus().merger.add_selfmodrule(ChainAlias(_NEXUS))
-if settings.SETTINGS["feature_rules"]["alias"]:
-    control.nexus().merger.add_selfmodrule(VanillaAlias())
+

--- a/caster/lib/tests/unit/mergerule.py
+++ b/caster/lib/tests/unit/mergerule.py
@@ -5,7 +5,7 @@ from caster.apps.eclipse import EclipseCCR
 from caster.lib.ccr.java.java import Java
 from caster.lib.ccr.javascript.javascript import Javascript
 from caster.lib.ccr.python.python import Python
-from caster.lib.ccr.recording.alias import VanillaAlias
+from caster.lib.ccr.recording.alias import Alias
 from caster.lib.dfplus.merge.mergerule import MergeRule
 
 
@@ -52,7 +52,7 @@ class TestMergeRule(unittest.TestCase):
         python_specs = len(python.mapping_actual().keys())
         java = Java()
         java_specs = len(java.mapping_actual().keys())
-        vanilla = VanillaAlias(refresh=False)
+        vanilla = Alias(refresh=False)
         vanilla_specs = len(vanilla.mapping_actual().keys())
         _merged = python.merge(java)
         self.assertEqual(python_specs, len(python.mapping_actual().keys()))


### PR DESCRIPTION
Both in the documentation and the CodeBase 'vanilla alias' has been replaced with just 'alias' This is to reflect an earlier change that simplified alias https://github.com/synkarius/caster/pull/245