### PR TITLE
Cleaning up the R module

### DIFF
--- a/caster/doc/readthedocs/CCR languages quick reference.md
+++ b/caster/doc/readthedocs/CCR languages quick reference.md
@@ -315,7 +315,7 @@ lodge and|` and `|||``
 # R
 Command | Output | | Command | Output
 ---|---|---|---|---
-`fun <function>`|`<function>()`||lodge not|`!`
+`<function>`|`<function>()`||lodge not|`!`
 NA|`NA`||lodge or| &#124; &#124;
 add comment|`#`||print to console|`print()`
 assign|` <- `||return|`return()`
@@ -330,11 +330,12 @@ iffae|`if ()`||value not|`NULL`
 import|`library()`||value true|`TRUE`
 lodge and|` && `||while loop|`while ()`
 
-## Functions
-Should all be prefixed with `fun `  
+## Core/tidyverse functions
+If you are having trouble with over-recognition (R commands appearing where you don't want them) due to the large number of commands, consider adding a prefix to the `<function>` command - line 93 - in lib/ccr/r/r.py to increase phonetic distinctness.
 
 Command | Output | | Command | Output
 ---|---|---|---|---
+``|``||length|`length()`
 (LM / linear model)|`lm()`||library|`library()`
 arrange|`arrange()`||list|`list()`
 as character|`as.character()`||mean|`mean()`
@@ -347,27 +348,37 @@ case when|`case_when()`||select|`select()`
 count|`count()`||starts with|`starts_with()`
 drop NA|`drop_na()`||string contains|`str_contains()`
 filter|`filter()`||string detect|`str_detect()`
-full join|`full_join()`||string replace|`string_replace()`
-gather|`gather()`||string replace all|`string_replace_all()`
+full join|`full_join()`||string replace|`str_replace()`
+gather|`gather()`||string replace all|`str_replace_all()`
 group by|`group_by()`||sum|`sum()`
 head|`head()`||summarise|`summarise()`
-inner join|`inner_join()`||trim white space|`trimws()`
-left join|`left_join()`||ungroup|`ungroup()`
-length|`length()`||vector|`c()`
+inner join|`inner_join()`||tail|`tail()`
+install packages|`install.packages()`||trim white space|`trimws()`
+is NA|`is.na()`||ungroup|`ungroup()`
+left join|`left_join()`||vector|`c()`
 
-## Graph functions
+## Graph plotting functions
 Should all be prefixed with `graph `
-
 Command | Output | | Command | Output
 ---|---|---|---|---
 ``|``||line [plot]|`geom_line()`
 aesthetics|`aes()`||path [plot]|`geom_path()`
 column [plot]|`geom_col()`||plot|`ggplot()`
 density [plot]|`geom_density()`||point [plot]|`geom_point()`
-ex limit|`xlim()`||save|`ggsave()`
-facet grid|`facet_grid()`||smooth [plot]|`geom_smooth()`
-histogram [plot]|`geom_histogram()`||theme minimal|`theme_minimal()`
+ex label|`xlab()`||save|`ggsave()`
+ex limit|`xlim()`||smooth [plot]|`geom_smooth()`
+facet grid|`facet_grid()`||theme minimal|`theme_minimal()`
+histogram [plot]|`geom_histogram()`||why label|`ylab()`
 labels|`labs()`||why limit|`ylim()`
+
+## Pacman functions
+Should all be prefixed with `pack `
+Command | Output | | Command | Output
+---|---|---|---|---
+``|``||install version|`p_install_version()`
+install|`p_install()`||load|`p_load()`
+install hub|`p_install_gh()`||unload|`p_unload()`
+install temp|`p_temp()`||update|`p_update()`
 
 
 # Rust

--- a/caster/doc/readthedocs/CCR languages quick reference.md
+++ b/caster/doc/readthedocs/CCR languages quick reference.md
@@ -315,43 +315,57 @@ lodge and|` and `|||``
 # R
 Command | Output | | Command | Output
 ---|---|---|---|---
-NA|`NA`||graph smooth [plot]|`geom_smooth()`
-add comment|`#`||group by|`group_by()`
-arrange|`arrange()`||head of|`head()`
-as character|`as.character()`||iffae|`if ()`
-as data frame|`as.data.frame()`||import|`library()`
-as double|`as.double()`||inner join|`inner_join()`
-as factor|`as.factor()`||left join|`left_join()`
-as numeric|`as.numeric()`||length of|`length()`
-assign|` <- `||library|`library()`
-bind rows|`bind_rows()`||list of|`list()`
-breaker|`break`||lodge and|` && `
-case when|`case_when()`||lodge not|`!`
-contained in|` %in% `||lodge or| &#124; &#124;
-count|`count()`||mutate|`mutate()`
-deeply|`dplyr`||names of|`names()`
-dot (our/are)|`.R`||paste of|`paste0()`
-filter|`filter()`||print to console|`print()`
-for each|`for ( in ):`||rename|`rename()`
-for loop|`for (i in 1:)`||return|`return()`
-full join|`full_join()`||see as vee|`csv`
-function|`function()`||select|`select()`
-gather|`gather()`||shell iffae / LFA|`elseif ()`
-gee aesthetics|`aes()`||shells|`else `
-gee ex label|`xlab()`||slurp / chain|` %>% `
-gee ex limit|`xlim()`||summarise|`summarise()`
-gee labels|`labs()`||tell (slurp / chain)|`{end of line} %>% {newline}`
-gee plot|`ggplot()`||tell add|`{end of line} + {newline}`
-gee theme|`theme()`||tidier|`tidyr`
-gee title|`ggtitle()`||tidy verse|`tidyverse`
-gee why label|`ylab()`||trim white space|`trimws()`
-gee why limit|`ylim()`||ungroup|`ungroup()`
-graph (scatter / point) [plot]|`geom_point()`||value false|`FALSE`
-graph column [plot]|`geom_col()`||value not|`NULL`
-graph density [plot]|`geom_density()`||value true|`TRUE`
-graph histogram [plot]|`geom_histogram()`||vector of|`c()`
-graph line [plot]|`geom_line()`||while loop|`while ()`
-graph path [plot]|`geom_path()`|||``
+`fun <function>`|`<function>()`||lodge not|`!`
+NA|`NA`||lodge or| &#124; &#124;
+add comment|`#`||print to console|`print()`
+assign|` <- `||return|`return()`
+breaker|`break`||see as vee|`csv`
+contained in|` %in% `||shells|`else `
+dot (our/are)|`.R`||slurp / chain|` %>% `
+for each|`for ( in ):`||tell (slurp / chain)|`{end of line} %>% {newline}`
+for loop|`for (i in 1:)`||tell add|`{end of line} + {newline}`
+function|`function()`||tidy verse|`tidyverse`
+`graph <ggfun>`|`<ggfun>()`||value false|`FALSE`
+iffae|`if ()`||value not|`NULL`
+import|`library()`||value true|`TRUE`
+lodge and|` && `||while loop|`while ()`
+
+## Functions
+Should all be prefixed with `fun `
+Command | Output | | Command | Output
+---|---|---|---|---
+(LM / linear model)|`lm()`||library|`library()`
+arrange|`arrange()`||list|`list()`
+as character|`as.character()`||mean|`mean()`
+as data frame|`as.data.frame()`||mutate|`mutate()`
+as double|`as.double()`||names|`names()`
+as factor|`as.factor()`||paste|`paste0()`
+as numeric|`as.numeric()`||read CSV|`read_csv()`
+bind rows|`bind_rows()`||rename|`rename()`
+case when|`case_when()`||select|`select()`
+count|`count()`||starts with|`starts_with()`
+drop NA|`drop_na()`||string contains|`str_contains()`
+filter|`filter()`||string detect|`str_detect()`
+full join|`full_join()`||string replace|`string_replace()`
+gather|`gather()`||string replace all|`string_replace_all()`
+group by|`group_by()`||sum|`sum()`
+head|`head()`||summarise|`summarise()`
+inner join|`inner_join()`||trim white space|`trimws()`
+left join|`left_join()`||ungroup|`ungroup()`
+length|`length()`||vector|`c()`
+
+## Graph functions
+Should all be prefixed with `graph `
+Command | Output | | Command | Output
+---|---|---|---|---
+|``||line [plot]|`geom_line()`
+aesthetics|`aes()`||path [plot]|`geom_path()`
+column [plot]|`geom_col()`||plot|`ggplot()`
+density [plot]|`geom_density()`||point [plot]|`geom_point()`
+ex limit|`xlim()`||save|`ggsave()`
+facet grid|`facet_grid()`||smooth [plot]|`geom_smooth()`
+histogram [plot]|`geom_histogram()`||theme minimal|`theme_minimal()`
+labels|`labs()`||why limit|`ylim()`
 
 
 # Rust

--- a/caster/doc/readthedocs/CCR languages quick reference.md
+++ b/caster/doc/readthedocs/CCR languages quick reference.md
@@ -331,7 +331,8 @@ import|`library()`||value true|`TRUE`
 lodge and|` && `||while loop|`while ()`
 
 ## Functions
-Should all be prefixed with `fun `
+Should all be prefixed with `fun `  
+
 Command | Output | | Command | Output
 ---|---|---|---|---
 (LM / linear model)|`lm()`||library|`library()`
@@ -356,6 +357,7 @@ length|`length()`||vector|`c()`
 
 ## Graph functions
 Should all be prefixed with `graph `
+
 Command | Output | | Command | Output
 ---|---|---|---|---
 |``||line [plot]|`geom_line()`

--- a/caster/doc/readthedocs/CCR languages quick reference.md
+++ b/caster/doc/readthedocs/CCR languages quick reference.md
@@ -360,7 +360,7 @@ Should all be prefixed with `graph `
 
 Command | Output | | Command | Output
 ---|---|---|---|---
-|``||line [plot]|`geom_line()`
+``|``||line [plot]|`geom_line()`
 aesthetics|`aes()`||path [plot]|`geom_path()`
 column [plot]|`geom_col()`||plot|`ggplot()`
 density [plot]|`geom_density()`||point [plot]|`geom_point()`

--- a/caster/lib/ccr/r/r.py
+++ b/caster/lib/ccr/r/r.py
@@ -87,14 +87,16 @@ class Rlang(MergeRule):
         "see as vee":
             R(Text("csv"), rdescript="Rlang: csv"),
 
-        # dplyr and tidyr keywords: https://www.rstudio.com/wp-content/uploads/2015/02/data-wrangling-cheatsheet.pdf
+
         "tidy verse":
             R(Text("tidyverse"), rdescript="Rlang: tidyverse"),
-        "fun <function>":
+        "<function>":
             R(Text("%(function)s()") + Key("left"), rdescript="Rlang: insert a function"),
         "graph <ggfun>":
             R(Text("%(ggfun)s()") + Key("left"),
               rdescript="Rlang: insert a ggplot function"),
+        "pack <pacfun>":
+            R(Text("%(pacfun)s()") + Key("left"), rdescript="Rlang: insert a pacman function"),
     }
 
     extras = [
@@ -117,6 +119,8 @@ class Rlang(MergeRule):
                 "group by": "group_by",
                 "head": "head",
                 "inner join": "inner_join",
+                "install packages":"install.packages",
+                "is NA":"is.na",
                 "left join": "left_join",
                 "length": "length",
                 "library": "library",
@@ -131,11 +135,12 @@ class Rlang(MergeRule):
                 "select": "select",
                 "string contains": "str_contains",
                 "string detect": "str_detect",
-                "string replace": "string_replace",
-                "string replace all": "string_replace_all",
+                "string replace": "str_replace",
+                "string replace all": "str_replace_all",
                 "starts with": "starts_with",
                 "sum": "sum",
                 "summarise": "summarise",
+                "tail":"tail",
                 "trim white space": "trimws",
                 "ungroup": "ungroup",
                 "vector": "c",
@@ -145,6 +150,7 @@ class Rlang(MergeRule):
                 "aesthetics": "aes",
                 "column [plot]": "geom_col",
                 "density [plot]": "geom_density",
+                "ex label":"xlab",
                 "ex limit": "xlim",
                 "facet grid": "facet_grid",
                 "histogram [plot]": "geom_histogram",
@@ -156,7 +162,18 @@ class Rlang(MergeRule):
                 "save": "ggsave",
                 "smooth [plot]": "geom_smooth",
                 "theme minimal": "theme_minimal",
+                "why label":"ylab",
                 "why limit": "ylim",
+            }),
+        Choice(
+            "pacfun", {
+                "install":"p_install",
+                "install hub":"p_install_gh",
+                "install version":"p_install_version",
+                "install temp":"p_temp",
+                "load":"p_load",
+                "unload":"p_unload",
+                "update":"p_update",
             }),
     ]
     defaults = {}

--- a/caster/lib/ccr/r/r.py
+++ b/caster/lib/ccr/r/r.py
@@ -4,14 +4,15 @@ Created on May 23, 2017
 @author: shippy
 '''
 
-from dragonfly import Key, Text, Dictation, MappingRule
+from dragonfly import Key, Text, Dictation, MappingRule, Choice
 
 from caster.lib import control
 from caster.lib.ccr.standard import SymbolSpecs
 from caster.lib.dfplus.merge.mergerule import MergeRule
 from caster.lib.dfplus.state.short import R
 
-
+def rfunction(function):
+    return (Text(function + "()") + Key("left"))
 
 class Rlang(MergeRule):
     auto = [".R", ".r"]
@@ -67,8 +68,7 @@ class Rlang(MergeRule):
             R(Text("FALSE"), rdescript="Rlang: False"),
 
         # Rlang specific
-        "library":
-            R(Text("library()") + Key("left"), rdescript="Rlang: Import"),
+
         "assign":
             R(Text(" <- "), rdescript="Rlang: Assignment"),
         "contained in":
@@ -84,113 +84,83 @@ class Rlang(MergeRule):
             R(Text("NA"), rdescript="Rlang: Not Available"),
         "shell iffae | LFA":
             R(Text("elseif ()") + Key("left"), rdescript="Rlang: Else If"),
-        "length of":
-            R(Text("length()") + Key("left"), rdescript="Rlang: Length"),
-        "names of":
-            R(Text("names()") + Key("left"), rdescript="Rlang: Names"),
-        "head of":
-            R(Text("head()") + Key("left"), rdescript="Rlang: Head"),
-        "paste of":
-            R(Text("paste0()") + Key("left"), rdescript="Rlang: Paste"),
-        "trim white space":
-            R(Text("trimws()") + Key("left"), rdescript="Rlang: trim whitespace"),
-        #
-        "as factor":
-            R(Text("as.factor()") + Key("left"), rdescript="Rlang: Convert to factor"),
-        "as numeric":
-            R(Text("as.numeric()") + Key("left"), rdescript="Rlang: Convert To Integer"),
-        "as double":
-            R(Text("as.double()") + Key("left"), rdescript="Rlang: Convert To Floating-Point"),
-        "as character":
-            R(Text("as.character()") + Key("left"), rdescript="Rlang: Convert To character"),
-        "as data frame":
-            R(Text("as.data.frame()") + Key("left"), rdescript="Rlang: Convert To Data Frame"),
-        #
-        "vector of":
-            R(Text("c()") + Key("left"), rdescript="Rlang: Vector"),
-        "list of":
-            R(Text("list()") + Key("left"), rdescript="Rlang: List"),
         "dot (our|are)":
             R(Text(".R"), rdescript="Rlang: .py"),
         "see as vee":
             R(Text("csv"), rdescript="Rlang: csv"),
-        # ggplot keywords
-        "gee plot":
-            R(Text("ggplot()") + Key('left'), rdescript="Rlang: ggplot"),
-        "gee aesthetics":
-            R(Text("aes()") + Key('left'), rdescript="Rlang: ggplot::aes"),
-        "gee theme":
-            R(Text("theme()") + Key('left'), rdescript="Rlang: ggplot::aes"),
-        "gee title":
-            R(Text("ggtitle()") + Key('left'), rdescript="Rlang: ggplot::ggtitle"),
-        "gee ex label":
-            R(Text("xlab()") + Key('left'), rdescript="Rlang: ggplot::ggtitle"),
-        "gee why label":
-            R(Text("ylab()") + Key('left'), rdescript="Rlang: ggplot::ggtitle"),
-        "gee labels":
-            R(Text("labs()") + Key('left'), rdescript="Rlang: ggplot::labels"),
-        "gee ex limit":
-            R(Text("xlim()") + Key('left'), rdescript="Rlang: ggplot::ggtitle"),
-        "gee why limit":
-            R(Text("ylim()") + Key('left'), rdescript="Rlang: ggplot::ggtitle"),
-        "graph (scatter | point) [plot]":
-            R(Text("geom_point()") + Key('left'), rdescript="Rlang: ggplot::scatterplot"),
-        "graph line [plot]":
-            R(Text("geom_line()") + Key('left'), rdescript="Rlang: ggplot::scatterplot"),
-        "graph path [plot]":
-            R(Text("geom_path()") + Key('left'), rdescript="Rlang: ggplot::scatterplot"),
-        "graph smooth [plot]":
-            R(Text("geom_smooth()") + Key('left'), rdescript="Rlang: ggplot::scatterplot"),
-        "graph column [plot]":
-            R(Text("geom_col()") + Key('left'), rdescript="Rlang: ggplot::scatterplot"),
-        "graph histogram [plot]":
-            R(Text("geom_histogram()") + Key('left'),
-              rdescript="Rlang: ggplot::scatterplot"),
-        "graph density [plot]":
-            R(Text("geom_density()") + Key('left'),
-              rdescript="Rlang: ggplot::scatterplot"),
 
         # dplyr and tidyr keywords: https://www.rstudio.com/wp-content/uploads/2015/02/data-wrangling-cheatsheet.pdf
-        "deeply":
-            R(Text("dplyr"), rdescript="Rlang: dplyr"),
-        "tidier":
-            R(Text("tidyr"), rdescript="Rlang: tidyr"),
+
         "tidy verse":
             R(Text("tidyverse"), rdescript="Rlang: tidyverse"),
-        "arrange":
-            R(Text("arrange()") + Key('left'), rdescript="Rlang: dplyr::arrange"),
-        "rename":
-            R(Text("rename()") + Key('left'), rdescript="Rlang: dplyr::rename"),
-        "filter":
-            R(Text("filter()") + Key('left'), rdescript="Rlang: dplyr::filter"),
-        "select":
-            R(Text("select()") + Key('left'), rdescript="Rlang: dplyr::select"),
-        "summarise":
-            R(Text("summarise()") + Key('left'), rdescript="Rlang: dplyr::summarise"),
-        "count":
-            R(Text("count()") + Key('left'), rdescript="Rlang: dplyr::count"),
-        "mutate":
-            R(Text("mutate()") + Key('left'), rdescript="Rlang: dplyr::mutate"),
-        "group by":
-            R(Text("group_by()") + Key('left'), rdescript="Rlang: dplyr::group_by"),
-        "ungroup":
-            R(Text("ungroup()"), rdescript="Rlang: dplyr::ungroup"),
-        "bind rows":
-            R(Text("bind_rows()") + Key('left'), rdescript="Rlang: dplyr::bind_rows"),
-        "left join":
-            R(Text("left_join()") + Key('left'), rdescript="Rlang: dplyr::left_join"),
-        "inner join":
-            R(Text("inner_join()") + Key('left'), rdescript="Rlang: dplyr::inner_join"),
-        "full join":
-            R(Text("full_join()") + Key('left'), rdescript="Rlang: dplyr::full_join"),
-        "case when":
-            R(Text("case_when()") + Key('left'), rdescript="Rlang: dplyr::case_when"),
-        "gather":
-            R(Text("gather()") + Key('left'), rdescript="Rlang: tidyr::gather"),
+
+        "fun <function>":
+            R(rfunction("%(function)s"), rdescript="Rlang: insert a function"),
+
+        "graph <ggfun>":
+            R(rfunction("%(ggfun)s"), rdescript="Rlang: insert a ggplot function"),
     }
 
     extras = [
         Dictation("text"),
+        Choice("function", {
+            "arrange": "arrange",
+            "as character": "as.character",
+            "as data frame": "as.data.frame",
+            "as double": "as.double",
+            "as factor": "as.factor",
+            "as numeric": "as.numeric",
+            "bind rows": "bind_rows",
+            "case when": "case_when",
+            "count": "count",
+            "drop NA":"drop_na",
+            "filter": "filter",
+            "full join": "full_join",
+            "gather": "gather",
+            "group by": "group_by",
+            "head": "head",
+            "inner join": "inner_join",
+            "left join": "left_join",
+            "length": "length",
+            "library": "library",
+            "list": "list",
+            "(LM | linear model)": "lm",
+            "mean":"mean",
+            "mutate": "mutate",
+            "names": "names",
+            "paste": "paste0",
+            "read CSV":"read_csv",
+            "rename": "rename",
+            "select": "select",
+            "string contains":"str_contains",
+            "string detect":"str_detect",
+            "string replace":"string_replace",
+            "string replace all":"string_replace_all",
+            "starts with":"starts_with",
+            "sum":"sum",
+            "summarise": "summarise",
+            "trim white space": "trimws",
+            "ungroup": "ungroup",
+            "vector": "c",
+        }),
+        Choice("ggfun", {
+            "aesthetics": "aes",
+            "column [plot]": "geom_col",
+            "density [plot]": "geom_density",
+            "ex limit":"xlim",
+            "facet grid": "facet_grid",
+            "histogram [plot]": "geom_histogram",
+            "labels": "labs",
+            "line [plot]": "geom_line",
+            "path [plot]": "geom_path",
+            "plot": "ggplot",
+            "point [plot]": "geom_point",
+            "save":"ggsave",
+            "smooth [plot]": "geom_smooth",
+            "theme minimal": "theme_minimal",
+            "why limit":"ylim",
+        }),
+
     ]
     defaults = {}
 

--- a/caster/lib/ccr/r/r.py
+++ b/caster/lib/ccr/r/r.py
@@ -11,8 +11,6 @@ from caster.lib.ccr.standard import SymbolSpecs
 from caster.lib.dfplus.merge.mergerule import MergeRule
 from caster.lib.dfplus.state.short import R
 
-def rfunction(function):
-    return (Text(function + "()") + Key("left"))
 
 class Rlang(MergeRule):
     auto = [".R", ".r"]
@@ -95,10 +93,10 @@ class Rlang(MergeRule):
             R(Text("tidyverse"), rdescript="Rlang: tidyverse"),
 
         "fun <function>":
-            R(rfunction("%(function)s"), rdescript="Rlang: insert a function"),
+            R(Text("%(function)s()") + Key("left"), rdescript="Rlang: insert a function"),
 
         "graph <ggfun>":
-            R(rfunction("%(ggfun)s"), rdescript="Rlang: insert a ggplot function"),
+            R(Text("%(ggfun)s()") + Key("left"), rdescript="Rlang: insert a ggplot function"),
     }
 
     extras = [

--- a/caster/lib/ccr/r/r.py
+++ b/caster/lib/ccr/r/r.py
@@ -66,7 +66,6 @@ class Rlang(MergeRule):
             R(Text("FALSE"), rdescript="Rlang: False"),
 
         # Rlang specific
-
         "assign":
             R(Text(" <- "), rdescript="Rlang: Assignment"),
         "contained in":
@@ -75,7 +74,8 @@ class Rlang(MergeRule):
         "slurp | chain":
             R(Key('space, percent, rangle, percent, space'), rdescript="Rlang: Pipe"),
         "tell (slurp | chain)":
-            R(Key('end, space, percent, rangle, percent, enter'), rdescript="Rlang: Pipe at end"),
+            R(Key('end, space, percent, rangle, percent, enter'),
+              rdescript="Rlang: Pipe at end"),
         "tell add":
             R(Key('end, space, plus, enter'), rdescript="Rlang: plus at end"),
         "NA":
@@ -88,77 +88,76 @@ class Rlang(MergeRule):
             R(Text("csv"), rdescript="Rlang: csv"),
 
         # dplyr and tidyr keywords: https://www.rstudio.com/wp-content/uploads/2015/02/data-wrangling-cheatsheet.pdf
-
         "tidy verse":
             R(Text("tidyverse"), rdescript="Rlang: tidyverse"),
-
         "fun <function>":
             R(Text("%(function)s()") + Key("left"), rdescript="Rlang: insert a function"),
-
         "graph <ggfun>":
-            R(Text("%(ggfun)s()") + Key("left"), rdescript="Rlang: insert a ggplot function"),
+            R(Text("%(ggfun)s()") + Key("left"),
+              rdescript="Rlang: insert a ggplot function"),
     }
 
     extras = [
         Dictation("text"),
-        Choice("function", {
-            "arrange": "arrange",
-            "as character": "as.character",
-            "as data frame": "as.data.frame",
-            "as double": "as.double",
-            "as factor": "as.factor",
-            "as numeric": "as.numeric",
-            "bind rows": "bind_rows",
-            "case when": "case_when",
-            "count": "count",
-            "drop NA":"drop_na",
-            "filter": "filter",
-            "full join": "full_join",
-            "gather": "gather",
-            "group by": "group_by",
-            "head": "head",
-            "inner join": "inner_join",
-            "left join": "left_join",
-            "length": "length",
-            "library": "library",
-            "list": "list",
-            "(LM | linear model)": "lm",
-            "mean":"mean",
-            "mutate": "mutate",
-            "names": "names",
-            "paste": "paste0",
-            "read CSV":"read_csv",
-            "rename": "rename",
-            "select": "select",
-            "string contains":"str_contains",
-            "string detect":"str_detect",
-            "string replace":"string_replace",
-            "string replace all":"string_replace_all",
-            "starts with":"starts_with",
-            "sum":"sum",
-            "summarise": "summarise",
-            "trim white space": "trimws",
-            "ungroup": "ungroup",
-            "vector": "c",
-        }),
-        Choice("ggfun", {
-            "aesthetics": "aes",
-            "column [plot]": "geom_col",
-            "density [plot]": "geom_density",
-            "ex limit":"xlim",
-            "facet grid": "facet_grid",
-            "histogram [plot]": "geom_histogram",
-            "labels": "labs",
-            "line [plot]": "geom_line",
-            "path [plot]": "geom_path",
-            "plot": "ggplot",
-            "point [plot]": "geom_point",
-            "save":"ggsave",
-            "smooth [plot]": "geom_smooth",
-            "theme minimal": "theme_minimal",
-            "why limit":"ylim",
-        }),
-
+        Choice(
+            "function", {
+                "arrange": "arrange",
+                "as character": "as.character",
+                "as data frame": "as.data.frame",
+                "as double": "as.double",
+                "as factor": "as.factor",
+                "as numeric": "as.numeric",
+                "bind rows": "bind_rows",
+                "case when": "case_when",
+                "count": "count",
+                "drop NA": "drop_na",
+                "filter": "filter",
+                "full join": "full_join",
+                "gather": "gather",
+                "group by": "group_by",
+                "head": "head",
+                "inner join": "inner_join",
+                "left join": "left_join",
+                "length": "length",
+                "library": "library",
+                "list": "list",
+                "(LM | linear model)": "lm",
+                "mean": "mean",
+                "mutate": "mutate",
+                "names": "names",
+                "paste": "paste0",
+                "read CSV": "read_csv",
+                "rename": "rename",
+                "select": "select",
+                "string contains": "str_contains",
+                "string detect": "str_detect",
+                "string replace": "string_replace",
+                "string replace all": "string_replace_all",
+                "starts with": "starts_with",
+                "sum": "sum",
+                "summarise": "summarise",
+                "trim white space": "trimws",
+                "ungroup": "ungroup",
+                "vector": "c",
+            }),
+        Choice(
+            "ggfun", {
+                "aesthetics": "aes",
+                "column [plot]": "geom_col",
+                "density [plot]": "geom_density",
+                "ex limit": "xlim",
+                "facet grid": "facet_grid",
+                "histogram [plot]": "geom_histogram",
+                "labels": "labs",
+                "line [plot]": "geom_line",
+                "path [plot]": "geom_path",
+                "plot": "ggplot",
+                "point [plot]": "geom_point",
+                "save": "ggsave",
+                "smooth [plot]": "geom_smooth",
+                "theme minimal": "theme_minimal",
+                "why limit": "ylim",
+            }),
     ]
     defaults = {}
 


### PR DESCRIPTION
I've re-factored the R module. There were a large number of commands which all did basically the same thing – write a particular function and then move inside the brackets – which I've reduced to just a couple of commands, with options in the extras. There are a few benefits to this:
* Reduces code volume and repetition.
* Makes it easier and more intuitive to add new extras.
* Makes it easier to modify how the command works, e.g adding a prefix.

For consistency, I have made the prefix for all ggplot commands "graph". I have also added a prefix – "fun" – to the command which produces R functions. A small reduction in speed for a large gain in phonetic distinctness and a reduction in mistakes.