### PR TITLE
Hide or fix pylint errors 

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,11 @@
+[TYPECHECK]
+generated-members=pythoncom.*,wx.*
+
+[MASTER]
+extension-pkg-whitelist=pythoncom,wx,pydevd
+
+[MESSAGES CONTROL]
+
+disable=all
+
+enable=E

--- a/caster/apps/eclipse.py
+++ b/caster/apps/eclipse.py
@@ -46,8 +46,7 @@ class EclipseController(object):
             self.regex = True
             Key("delete, backspace").execute()
         else:
-            control.nexus().intermediary.text(
-                "Eclipse configuration failed (" + result + ")")
+            print("Eclipse configuration failed (%s)" % result)
 
     def lines_relative(self, back, n):
         if back:  #backward

--- a/caster/asynch/hmc/homunculus.py
+++ b/caster/asynch/hmc/homunculus.py
@@ -40,8 +40,8 @@ class Homunculus(tk.Tk):
             self.data = data.split("|")
             Label(
                 self,
-                text=" ".join(self.data[0].split(settings.HMC_SEPARATOR)),
-                name="pathlabel").pack()
+                text=" ".join(self.data[0].split(settings.HMC_SEPARATOR)), # pylint: disable=no-member
+                name="pathlabel").pack() 
             self.ext_box = Text(self, name="ext_box")
             self.ext_box.pack(side=tk.LEFT)
 

--- a/caster/lib/navigation.py
+++ b/caster/lib/navigation.py
@@ -9,7 +9,7 @@ from subprocess import Popen
 
 import dragonfly
 from caster.asynch.mouse.legion import LegionScanner
-from caster.lib import settings, utilities
+from caster.lib import control, settings, utilities
 from dragonfly import Choice, Clipboard, Key, Mouse, Text, monitors
 
 DIRECTION_STANDARD = {
@@ -234,9 +234,9 @@ def curse(direction, direction2, nnavi500, dokick):
     Mouse("<" + str(x) + ", " + str(y) + ">").execute()
     if int(dokick) != 0:
         if int(dokick) == 1:
-            left_click()
+            left_click(control.nexus())
         elif int(dokick) == 2:
-            right_click()
+            right_click(control.nexus())
 
 
 def next_line(semi):

--- a/caster/lib/utilities.py
+++ b/caster/lib/utilities.py
@@ -112,7 +112,7 @@ def remote_debug(who_called_it=None):
     if who_called_it is None:
         who_called_it = "An unidentified process"
     try:
-        import pydevd  # @UnresolvedImport
+        import pydevd  # @UnresolvedImport pylint: disable=import-error
         pydevd.settrace()
     except Exception:
         print("ERROR: " + who_called_it +


### PR DESCRIPTION
Either fixes errors highlighted by pylint, or hides them as appropriate. After this pylint -E should not display errors. Unfortunately it has to be run as pylint -E, but despite an ugly warning, the exit code of pylint is 0. Something to maybe consider for #274 if tests are not ready at the moment