### PR TITLE
Hotfix doc strings in settings.py

### DIFF
--- a/caster/lib/settings.py
+++ b/caster/lib/settings.py
@@ -35,12 +35,12 @@ WXTYPE_SETTINGS = "7"
 HMC_SEPARATOR = "[hmc]"
 
 WSR = False
-"""
-Validates 'Engine Path' in settings.toml
-"""
 
 
 def _validate_engine_path():
+'''
+Validates path 'Engine Path' in settings.toml
+'''
     if os.path.isfile(_SETTINGS_PATH):
         with io.open(_SETTINGS_PATH, "rt", encoding="utf-8") as toml_file:
             data = toml.loads(toml_file.read())
@@ -62,12 +62,10 @@ def _validate_engine_path():
         return _find_natspeak()
 
 
-""" 
-Finds engine 'natspeak.exe' path and verifies supported DNS versions via Windows Registry.
-"""
-
-
 def _find_natspeak():
+'''
+Finds engine 'natspeak.exe' path and verifies supported DNS versions via Windows Registry.
+'''
     print("Searching Windows Registry For DNS...")
     proc_arch = os.environ['PROCESSOR_ARCHITECTURE'].lower()
     proc_arch64 = os.environ['PROCESSOR_ARCHITEW6432'].lower()
@@ -116,9 +114,7 @@ def _find_natspeak():
     return ""
 
 
-""" 
-The defaults for every setting. Could be moved out into its own file.
-"""
+# The defaults for every setting. Could be moved out into its own file.
 _DEFAULT_SETTINGS = {
     "paths": {
         "BASE_PATH": BASE_PATH,
@@ -224,11 +220,9 @@ _DEFAULT_SETTINGS = {
     },
     "one time warnings": {}
 }
-""" 
-Internal Methods
-"""
 
 
+# Internal Methods
 def _save(data, path):
     '''only to be used for settings file'''
     try:
@@ -277,11 +271,7 @@ def _deep_merge_defaults(data, defaults):
     return data, changes
 
 
-"""
-Public interface:
-"""
-
-
+# Public interface:
 def save_config():
     '''Save the current in-memory settings to disk'''
     _save(SETTINGS, _SETTINGS_PATH)
@@ -304,10 +294,7 @@ def report_to_file(message, path=None):
         f.write(unicode(message) + "\n")
 
 
-"""
-Kick everything off.
-"""
-
+# Kick everything off.
 SETTINGS = _init(_SETTINGS_PATH)
 for path in [
         SETTINGS["paths"]["REMOTE_DEBUGGER_PATH"], SETTINGS["paths"]["WXPYTHON_PATH"]


### PR DESCRIPTION
Restored previous comments as needed and moved relevant doc strings inside functions with correct syntax.