### PR TITLE
Converts ccr.toml [selfmod] as true instead of false.

### DIFF
--- a/caster/lib/dfplus/merge/ccrmerger.py
+++ b/caster/lib/dfplus/merge/ccrmerger.py
@@ -98,7 +98,7 @@ class CCRMerger(object):
             self._config[CCRMerger._SELFMOD] = {}
         for name in self.selfmod_rule_names():
             if not name in self._config[CCRMerger._SELFMOD]:
-                self._config[CCRMerger._SELFMOD][name] = False
+                self._config[CCRMerger._SELFMOD][name] = True
                 changed = True
 
         if changed: self.save_config()


### PR DESCRIPTION
Option three defined in 'Alternative approaches managing settings for 'alias'/'chain alias' and 'record from history' spec #302'