### PR TITLE
Add "splat" and "shift click" commands

### DIFF
--- a/caster/lib/ccr/core/nav.py
+++ b/caster/lib/ccr/core/nav.py
@@ -191,6 +191,10 @@ class Navigation(MergeRule):
         "(<mtn_dir> | <mtn_mode> [<mtn_dir>]) [(<nnavi500> | <extreme>)]":
             R(Function(textformat.master_text_nav), rdescript="Keyboard Text Navigation"),
 
+        "shift click":
+            R(Key("shift:down") + Mouse("left") + Key("shift:up"),
+              rdescript="Mouse: Shift Click"),
+
         "stoosh [<nnavi500>]":
             R(Function(navigation.stoosh_keep_clipboard, nexus=_NEXUS), rspec="stoosh", rdescript="Copy"),
         "cut [<nnavi500>]":
@@ -198,6 +202,8 @@ class Navigation(MergeRule):
         "spark [<nnavi500>]":
             R(Function(navigation.drop_keep_clipboard, nexus=_NEXUS), rspec="spark", rdescript="Paste"),
 
+        "splat [<splatdir>] [<nnavi10>]":
+            R(Key("c-%(splatdir)s"), rspec="splat", rdescript="Splat") * Repeat(extra="nnavi10"),
         "deli [<nnavi50>]":
             R(Key("del/5"), rspec="deli", rdescript="Delete") * Repeat(extra="nnavi50"),
         "clear [<nnavi50>]":
@@ -288,6 +294,10 @@ class Navigation(MergeRule):
         Choice("extreme", {
             "Wally": "way",
         }),
+        Choice("splatdir", {
+            "lease":"backspace",
+            "ross":"delete",
+        }),
     ]
 
     defaults = {
@@ -299,7 +309,8 @@ class Navigation(MergeRule):
         "spacing": 0,
         "mtn_mode": None,
         "mtn_dir": "right",
-        "extreme": None
+        "extreme": None,
+        "splatdir":"backspace",
     }
 
 


### PR DESCRIPTION
A couple of commands which I have added for text navigation, which I find very useful.

* Splat command adds functionality for deleting whole words, in both directions, using the c-del and c-bkspc keystrokes. eg `splat three`, `splat ross`.
* Shift click does what it says on the tin.

I may make one or two other changes this week so I will update the docs in one go, separately.