### PR TITLE
Add complete spark formatting functionality

### DIFF
--- a/caster/lib/ccr/core/nav.py
+++ b/caster/lib/ccr/core/nav.py
@@ -75,12 +75,15 @@ class NavigationNon(MappingRule):
               rdescript="Mouse: Ctrl + Left Click"),
         "garb [<nnavi500>]":
             R(Mouse("left") + Mouse("left") + Function(
-                navigation.stoosh_keep_clipboard, nexus=_NEXUS),
-                rdescript="Highlight @ Mouse + Copy"),
+                navigation.stoosh_keep_clipboard,
+                nexus=_NEXUS,
+                capitalization=0,
+                spacing=0),
+              rdescript="Highlight @ Mouse + Copy"),
         "drop [<nnavi500>]":
             R(Mouse("left") + Mouse("left") + Function(
                 navigation.drop_keep_clipboard, nexus=_NEXUS),
-                rdescript="Highlight @ Mouse + Paste"),
+              rdescript="Highlight @ Mouse + Paste"),
         "sure stoosh":
             R(Key("c-c"), rdescript="Simple Copy"),
         "sure cut":
@@ -188,7 +191,7 @@ class Navigation(MergeRule):
         'shock [<nnavi50>]':
             R(Key("enter"), rspec="shock", rdescript="Enter")* Repeat(extra="nnavi50"),
 
-        "(<mtn_dir> | <mtn_mode> [<mtn_dir>]) [(<nnavi500> | <extreme>)]": 
+        "(<mtn_dir> | <mtn_mode> [<mtn_dir>]) [(<nnavi500> | <extreme>)]":
             R(Function(text_utils.master_text_nav), rdescript="Keyboard Text Navigation"),
 
         "shift click":
@@ -199,7 +202,7 @@ class Navigation(MergeRule):
             R(Function(navigation.stoosh_keep_clipboard, nexus=_NEXUS), rspec="stoosh", rdescript="Copy"),
         "cut [<nnavi500>]":
             R(Function(navigation.cut_keep_clipboard, nexus=_NEXUS), rspec="cut", rdescript="Cut"),
-        "spark [<nnavi500>]":
+        "spark [<nnavi500>] [(<capitalization> <spacing> | <capitalization> | <spacing>) (bow|bowel)]":
             R(Function(navigation.drop_keep_clipboard, nexus=_NEXUS), rspec="spark", rdescript="Paste"),
 
         "splat [<splatdir>] [<nnavi10>]":
@@ -222,22 +225,22 @@ class Navigation(MergeRule):
             R(Key("c-space"), rspec="Kraken", rdescript="Control Space"),
 
     # text formatting
-        "set [<big>] format (<capitalization> <spacing> | <capitalization> | <spacing>) (bow|bowel)":  
+        "set [<big>] format (<capitalization> <spacing> | <capitalization> | <spacing>) (bow|bowel)":
             R(Function(textformat.set_text_format), rdescript="Set Text Format"),
-        "clear caster [<big>] formatting":      
+        "clear caster [<big>] formatting":
             R(Function(textformat.clear_text_format), rdescript="Clear Caster Formatting"),
-        "peek [<big>] format":                  
+        "peek [<big>] format":
             R(Function(textformat.peek_text_format), rdescript="Peek Format"),
-        "(<capitalization> <spacing> | <capitalization> | <spacing>) (bow|bowel) <textnv> [brunt]":  
+        "(<capitalization> <spacing> | <capitalization> | <spacing>) (bow|bowel) <textnv> [brunt]":
             R(Function(textformat.master_format_text), rdescript="Text Format"),
-        "[<big>] format <textnv>":              
+        "[<big>] format <textnv>":
             R(Function(textformat.prior_text_format), rdescript="Last Text Format"),
-        "<word_limit> [<big>] format <textnv>": 
+        "<word_limit> [<big>] format <textnv>":
             R(Function(textformat.partial_format_text), rdescript="Partial Text Format"),
 
-        "hug <enclosure>":              
+        "hug <enclosure>":
             R(Function(text_utils.enclose_selected), rdescript="Enclose text "),
-        "dredge":                       
+        "dredge":
             R(Key("a-tab"), rdescript="Alt-Tab"),
 
     }
@@ -299,8 +302,8 @@ class Navigation(MergeRule):
             "big": "big",
         }),
         Choice("splatdir", {
-            "lease":"backspace",
-            "ross":"delete",
+            "lease": "backspace",
+            "ross": "delete",
         }),
     ]
 
@@ -315,7 +318,7 @@ class Navigation(MergeRule):
         "mtn_dir": "right",
         "extreme": None,
         "big": None,
-        "splatdir":"backspace",
+        "splatdir": "backspace",
     }
 
 

--- a/caster/lib/navigation.py
+++ b/caster/lib/navigation.py
@@ -135,6 +135,7 @@ def cut_keep_clipboard(nnavi500, nexus):
 
 def drop_keep_clipboard(nnavi500, nexus, capitalization, spacing):
     if capitalization != 0 or spacing != 0 or nnavi500 != 1:
+        cb = Clipboard(from_system=True)
         if nnavi500 > 1:
             max_tries = 20
             key = str(nnavi500)
@@ -152,7 +153,13 @@ def drop_keep_clipboard(nnavi500, nexus, capitalization, spacing):
         else:
             text = Clipboard.get_system_text()
 
-        textformat.master_format_text(capitalization, spacing, text)
+        formatted = textformat.TextFormat.formatted_text(capitalization, spacing, text)
+
+        Clipboard.set_system_text(formatted)
+        time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
+        Key("c-v").execute()
+        time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
+        cb.copy_to_system()
     # Maintain standard spark functionality for non-strings
     else:
         Key("c-v").execute()

--- a/caster/lib/navigation.py
+++ b/caster/lib/navigation.py
@@ -135,7 +135,6 @@ def cut_keep_clipboard(nnavi500, nexus):
 
 def drop_keep_clipboard(nnavi500, nexus, capitalization, spacing):
     if capitalization != 0 or spacing != 0 or nnavi500 != 1:
-        cb = Clipboard(from_system=True)
         if nnavi500 > 1:
             max_tries = 20
             key = str(nnavi500)
@@ -153,13 +152,7 @@ def drop_keep_clipboard(nnavi500, nexus, capitalization, spacing):
         else:
             text = Clipboard.get_system_text()
 
-        formatted = textformat.TextFormat.formatted_text(capitalization, spacing, text)
-
-        Clipboard.set_system_text(formatted)
-        time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
-        Key("c-v").execute()
-        time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
-        cb.copy_to_system()
+        textformat.master_format_text(capitalization, spacing, text)
     # Maintain standard spark functionality for non-strings
     else:
         Key("c-v").execute()

--- a/caster/lib/navigation.py
+++ b/caster/lib/navigation.py
@@ -9,7 +9,7 @@ from subprocess import Popen
 
 import dragonfly
 from caster.asynch.mouse.legion import LegionScanner
-from caster.lib import control, settings, utilities
+from caster.lib import control, settings, utilities, textformat
 from dragonfly import Choice, Clipboard, Key, Mouse, Text, monitors
 
 DIRECTION_STANDARD = {
@@ -124,7 +124,7 @@ def cut_keep_clipboard(nnavi500, nexus):
                 time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
                 nexus.clip[key] = Clipboard.get_system_text()
                 utilities.save_toml_file(
-                nexus.clip, settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
+                    nexus.clip, settings.SETTINGS["paths"]["SAVED_CLIPBOARD_PATH"])
             except Exception:
                 failure = True
                 utilities.simple_log()
@@ -133,27 +133,36 @@ def cut_keep_clipboard(nnavi500, nexus):
         cb.copy_to_system()
 
 
-def drop_keep_clipboard(nnavi500, nexus):
-    if nnavi500 == 1:
-        Key("c-v").execute()
-    else:
-        max_tries = 20
-        key = str(nnavi500)
+def drop_keep_clipboard(nnavi500, nexus, capitalization, spacing):
+    if capitalization != 0 or spacing != 0 or nnavi500 != 1:
         cb = Clipboard(from_system=True)
-        for i in range(0, max_tries):
-            failure = False
-            try:
-                if key in nexus.clip:
-                    Clipboard.set_system_text(nexus.clip[key])
-                    Key("c-v").execute()
-                    time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
-                else:
-                    dragonfly.get_engine().speak("slot empty")
-            except Exception:
-                failure = True
-            if not failure:
-                break
+        if nnavi500 > 1:
+            max_tries = 20
+            key = str(nnavi500)
+            for i in range(0, max_tries):
+                failure = False
+                try:
+                    if key in nexus.clip:
+                        text = nexus.clip[key]
+                    else:
+                        dragonfly.get_engine().speak("slot empty")
+                except Exception:
+                    failure = True
+                if not failure:
+                    break
+        else:
+            text = Clipboard.get_system_text()
+
+        formatted = textformat.TextFormat.formatted_text(capitalization, spacing, text)
+
+        Clipboard.set_system_text(formatted)
+        time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
+        Key("c-v").execute()
+        time.sleep(settings.SETTINGS["miscellaneous"]["keypress_wait"]/1000.)
         cb.copy_to_system()
+    # Maintain standard spark functionality for non-strings
+    else:
+        Key("c-v").execute()
 
 
 def duple_keep_clipboard(nnavi50):


### PR DESCRIPTION
Inspired by #278. A few points:

* If the user just says "spark", only ctrl-v is executed. This is important to make sure that the command still works as expected for images, files etc.
* Whether or not "bow" is needed as a closer is questionable, I've left it in for now.
* The original (ages ago) suggestion for this feature suggested that the command should actually edit the clipboard in situ. I personally think this is a better solution as it preserves the original data.

Sample command: "shackle cut spark yell bow". Capitalise the whole line.

EDIT: I tried changing this to use Text() instead of copying in and out of the clipboard. It's more elegant but unfortunately takes ages (potentially minutes) to execute long strings, so I think the clipboard is the better option.