### PR TITLE
Fixed bug introduced in #326

### DIFF
--- a/caster/lib/alphanumeric.py
+++ b/caster/lib/alphanumeric.py
@@ -79,10 +79,10 @@ def letters(big, dict1, dict2, letter):
     d1 = str(dict1)
     if d1 != "":
         Text(d1).execute()
-    if str(big) != "":
+    if big:
         Key("shift:down").execute()
     letter.execute()
-    if str(big) != "":
+    if big:
         Key("shift:up").execute()
     d2 = str(dict2)
     if d2 != "":
@@ -90,11 +90,10 @@ def letters(big, dict1, dict2, letter):
 
 
 def letters2(big, letter):
-    if str(big) != "":
-        Key("shift:down").execute()
-    Key(letter).execute()
-    if str(big) != "":
-        Key("shift:up").execute()
+    if big:
+        Key(letter.capitalize()).execute()
+    else:
+        Key(letter).execute()
 
 
 '''for fun'''

--- a/caster/lib/ccr/core/alphabet.py
+++ b/caster/lib/ccr/core/alphabet.py
@@ -17,11 +17,11 @@ class Alphabet(MergeRule):
     extras = [
         alphanumeric.get_alphabet_choice("letter"),
         Choice("big", {
-            "big": "big",
+            "big": True,
         }),
     ]
     defaults = {
-        "big": "",
+        "big": False,
     }
 
 

--- a/caster/lib/ccr/core/nav.py
+++ b/caster/lib/ccr/core/nav.py
@@ -299,7 +299,7 @@ class Navigation(MergeRule):
             "Wally": "way",
         }),
         Choice("big", {
-            "big": "big",
+            "big": True,
         }),
         Choice("splatdir", {
             "lease": "backspace",
@@ -317,7 +317,7 @@ class Navigation(MergeRule):
         "mtn_mode": None,
         "mtn_dir": "right",
         "extreme": None,
-        "big": None,
+        "big": False,
         "splatdir": "backspace",
     }
 

--- a/caster/lib/ccr/latex/latex.py
+++ b/caster/lib/ccr/latex/latex.py
@@ -21,7 +21,7 @@ def back_curl(first, second):
 
 
 def symbol_letters(big, symbol):
-    if big == "big":
+    if big:
         symbol = symbol.title()
     Text(str(symbol)).execute()
 
@@ -182,11 +182,11 @@ class LaTeX(MergeRule):
                 "right": "right)",
             }),
         Choice("big", {
-            "big": "big",
+            "big": True,
         }),
     ]
     defaults = {
-        "big": "",
+        "big": False,
         "packages": "",
     }
 


### PR DESCRIPTION
When grammars are combined for CCR the `extras` get overwritten by the latest one as they are merged.  This behavior introduced a bug in the last merge which caused the spoken alphabet to wrap the letter in `SHIFT` keystrokes.
In this case, the `Choice` extra "big" existed several times for the same purpose but was implemented slightly differently. I made these uses consistent and simplified things.
I also refactored part of the code for the spoken alphabet to handle capital letters in a more platform neutral way.
I left `letters` in `alphanumeric.py` as it was because I couldn't find any use of it in the code base. I think the function might be an artifact from when @synkarius was originally developing Caster.
