### PR TITLE
File dialogue rule

### DIFF
--- a/caster/apps/file_dialogue.py
+++ b/caster/apps/file_dialogue.py
@@ -18,7 +18,8 @@ class FileDialogueRule(MergeRule):
         "[get] back [<n>]":
             R(Key("a-left"), rdescript="File Dialogue: Navigate back")*Repeat(extra="n"),
         "[get] forward [<n>]":
-            R(Key("a-right"), rdescript="File Dialogue: Navigate forward")*Repeat(extra="n"),
+            R(Key("a-right"), rdescript="File Dialogue: Navigate forward")*
+            Repeat(extra="n"),
         "(files | file list)":
             R(Key("a-d, f6:3"), rdescript="File Dialogue: Files list"),
         "navigation [pane]":
@@ -32,8 +33,14 @@ class FileDialogueRule(MergeRule):
     }
 
 
-context = AppContext(title="save file") | AppContext(title="save as") | AppContext(
-    title="select folder") | AppContext(title="open file") | AppContext(title="select file")
+dialogue_names = [
+    "open",
+    "select",
+]
+
+context = AppContext(title="save")
+for name in dialogue_names:
+    context = context | AppContext(title=name)
 
 grammar = Grammar("FileDialogue", context=context)
 if settings.SETTINGS["apps"]["filedialogue"]:

--- a/caster/apps/file_dialogue.py
+++ b/caster/apps/file_dialogue.py
@@ -1,0 +1,41 @@
+from dragonfly import (AppContext, Dictation, Grammar, IntegerRef, Key, MappingRule,
+                       Pause, Repeat, Text)
+from dragonfly.actions.action_mimic import Mimic
+
+from caster.lib import control, settings
+from caster.lib.dfplus.additions import IntegerRefST
+from caster.lib.dfplus.merge import gfilter
+from caster.lib.dfplus.merge.mergerule import MergeRule
+from caster.lib.dfplus.state.short import R
+
+class FileDialogueRule(MergeRule):
+    pronunciation = "file dialogue"
+
+    mapping = {
+	    "get up":                                
+		    R(Key("a-up"), rdescript="RStudio: Navigate up"),
+		"get back":                           
+		    R(Key("a-left"), rdescript="RStudio: Navigate back"),
+		"get forward":                        
+		    R(Key("a-right"), rdescript="RStudio: Navigate forward"),
+		"file list":                         
+		    R(Key("a-d, f6, f6, f6"), rdescript="RStudio: Files list"),
+		"navigation pane":                   
+		    R(Key("a-d, f6, f6"), rdescript="RStudio: Navigation pane"),
+		"filename":                   
+		    R(Key("a-d, f6, f6, f6, f6, f6"), rdescript="RStudio: File name"),
+	}
+    extras = [
+    ]
+    defaults = {}
+
+context = AppContext(title="save file") | AppContext(title="open file") | AppContext(title="save as")
+grammar = Grammar("FileDialogue", context=context)
+if settings.SETTINGS["apps"]["filedialogue"]:
+    if settings.SETTINGS["miscellaneous"]["rdp_mode"]:
+        control.nexus().merger.add_global_rule(FileDialogueRule())
+    else:
+        rule = FileDialogueRule()
+        gfilter.run_on(rule)
+        grammar.add_rule(FileDialogueRule(name="filedialogue"))
+        grammar.load()

--- a/caster/apps/file_dialogue.py
+++ b/caster/apps/file_dialogue.py
@@ -13,11 +13,11 @@ class FileDialogueRule(MergeRule):
     pronunciation = "file dialogue"
 
     mapping = {
-        "[get] up [<n>]":
+        "up [<n>]":
             R(Key("a-up"), rdescript="File Dialogue: Navigate up")*Repeat(extra="n"),
-        "[get] back [<n>]":
+        "back [<n>]":
             R(Key("a-left"), rdescript="File Dialogue: Navigate back")*Repeat(extra="n"),
-        "[get] forward [<n>]":
+        "forward [<n>]":
             R(Key("a-right"), rdescript="File Dialogue: Navigate forward")*
             Repeat(extra="n"),
         "(files | file list)":

--- a/caster/apps/file_dialogue.py
+++ b/caster/apps/file_dialogue.py
@@ -8,28 +8,33 @@ from caster.lib.dfplus.merge import gfilter
 from caster.lib.dfplus.merge.mergerule import MergeRule
 from caster.lib.dfplus.state.short import R
 
+
 class FileDialogueRule(MergeRule):
     pronunciation = "file dialogue"
 
     mapping = {
-	    "get up":                                
-		    R(Key("a-up"), rdescript="RStudio: Navigate up"),
-		"get back":                           
-		    R(Key("a-left"), rdescript="RStudio: Navigate back"),
-		"get forward":                        
-		    R(Key("a-right"), rdescript="RStudio: Navigate forward"),
-		"file list":                         
-		    R(Key("a-d, f6, f6, f6"), rdescript="RStudio: Files list"),
-		"navigation pane":                   
-		    R(Key("a-d, f6, f6"), rdescript="RStudio: Navigation pane"),
-		"filename":                   
-		    R(Key("a-d, f6, f6, f6, f6, f6"), rdescript="RStudio: File name"),
-	}
-    extras = [
-    ]
-    defaults = {}
+        "[get] up [<n>]":
+            R(Key("a-up"), rdescript="File Dialogue: Navigate up")*Repeat(extra="n"),
+        "[get] back [<n>]":
+            R(Key("a-left"), rdescript="File Dialogue: Navigate back")*Repeat(extra="n"),
+        "[get] forward [<n>]":
+            R(Key("a-right"), rdescript="File Dialogue: Navigate forward")*Repeat(extra="n"),
+        "(files | file list)":
+            R(Key("a-d, f6:3"), rdescript="File Dialogue: Files list"),
+        "navigation [pane]":
+            R(Key("a-d, f6:2"), rdescript="File Dialogue: Navigation pane"),
+        "[file] name":
+            R(Key("a-d, f6:5"), rdescript="File Dialogue: File name"),
+    }
+    extras = [IntegerRefST("n", 1, 10)]
+    defaults = {
+        "n": 1,
+    }
 
-context = AppContext(title="save file") | AppContext(title="open file") | AppContext(title="save as")
+
+context = AppContext(title="save file") | AppContext(title="save as") | AppContext(
+    title="select folder") | AppContext(title="open file") | AppContext(title="select file")
+
 grammar = Grammar("FileDialogue", context=context)
 if settings.SETTINGS["apps"]["filedialogue"]:
     if settings.SETTINGS["miscellaneous"]["rdp_mode"]:

--- a/caster/doc/readthedocs/Application Commands Quick Reference.md
+++ b/caster/doc/readthedocs/Application Commands Quick Reference.md
@@ -9,6 +9,7 @@
 - [Eclipse](#eclipse)
 - [Emacs](#emacs)
 - [Internet Explorer](#internet-explorer)
+- [File Dialogues](#file-dialogues)
 - [Firefox](#firefox)
 - [Flash Develop](#flash-develop)
 - [fman](#fman)
@@ -177,6 +178,13 @@
 | `(show / file / folder) properties` | `get forward` | `new folder` |
 | `address bar`                       | `get up`      |              |
 | `get back`                          | `new file`    |              |
+
+# File Dialogues
+
+| Command               | Command      | Command       |
+|:----------------------|:-------------|:--------------|
+| `up [n]`              | `back [n]`   | `forward [n]` |
+| `(files / file list)` | `navigation` | `[file] name` |
 
 # Firefox
 

--- a/caster/lib/settings.py
+++ b/caster/lib/settings.py
@@ -167,6 +167,7 @@ _DEFAULT_SETTINGS = {
         "eclipse": True,
         "emacs": True,
         "explorer": True,
+        "filedialogue": True,
         "firefox": True,
         "flashdevelop": True,
         "fman": True,


### PR DESCRIPTION
Implements #348 

Creates an app rule which identifies file dialogues by title and provides commands for navigating them. This method works in the programs I have tested it with.

To do:
* ~~test on more programs~~ Seems to work in all standard save/open dialogues. Some programs have their own, but I'm not sure there is much that can be done about that beyond creating separate rules for each. 
* ~~add more potential file dialogue window names to the context - browse? open folder? open project?~~ title finding seems to be fairly fuzzy, so "open" works for "open file" etc
* ~~Think about whether grammar can be improved~~
* ~~docs~~

This is an excellent idea though. Wish I'd thought of it!