### PR TITLE
Change lgl operators to element wise in r.py

### DIFF
--- a/caster/lib/ccr/r/r.py
+++ b/caster/lib/ccr/r/r.py
@@ -36,9 +36,9 @@ class Rlang(MergeRule):
         # (no do-while in Rlang)
         #
         SymbolSpecs.AND:
-            R(Text(" && "), rdescript="Rlang: And"),
+            R(Text(" & "), rdescript="Rlang: And"),
         SymbolSpecs.OR:
-            R(Text(" || "), rdescript="Rlang: Or"),
+            R(Text(" | "), rdescript="Rlang: Or"),
         SymbolSpecs.NOT:
             R(Text("!"), rdescript="Rlang: Not"),
         #


### PR DESCRIPTION
"Operators & and | perform element-wise operation producing result having length of the longer operand.

But && and || examines only the first element of the operands resulting into a single length logical vector."

The double logical operators are seldom preferred in R and tend to result in error prone code.