### PR TITLE
Update installation instructions

### DIFF
--- a/caster/bin/inno/dependencies/Pip Install Dependencies.bat
+++ b/caster/bin/inno/dependencies/Pip Install Dependencies.bat
@@ -1,8 +1,9 @@
 @echo off
-echo Installing: dragonfly2, wxPython, pillow
+echo Installing: setuptools, future, dragonfly2, wxPython, pillow, toml
 
 cd c:\python27\scripts
 pip install setuptools
+pip install future
 pip install dragonfly2
 pip install -U wxPython
 pip install pillow

--- a/caster/bin/inno/dependencies/Pip Install Dependencies.bat
+++ b/caster/bin/inno/dependencies/Pip Install Dependencies.bat
@@ -2,12 +2,13 @@
 echo Installing: setuptools, future, dragonfly2, wxPython, pillow, toml
 
 cd c:\python27\scripts
-pip install setuptools
-pip install future
-pip install dragonfly2
+pip install -U pip
+pip install -U setuptools
+pip install -U future
+pip install -U dragonfly2
 pip install -U wxPython
-pip install pillow
-pip install toml
+pip install -U pillow
+pip install -U toml
 
 
 

--- a/caster/bin/inno/dependencies/Pip Uninstall Dependencies.bat
+++ b/caster/bin/inno/dependencies/Pip Uninstall Dependencies.bat
@@ -1,5 +1,5 @@
 @echo off
-echo Uninstall dragonfly2, wxPython, pillow, six, pyperclip, pillow, pywin32
+echo Uninstall dragonfly2, wxPython, future, pillow, six, pyperclip, pillow, pywin32
 echo ####
 echo #### Warning! Only uninstall dependencies that are no longer used for all Python projects.
 echo ####
@@ -7,6 +7,7 @@ echo ####
 cd c:\python27\scripts
 pip uninstall dragonfly2
 pip uninstall wxPython
+pip uninstall future
 pip uninstall pillow
 pip uninstall six
 pip uninstall pyperclip

--- a/caster/doc/Installation.md
+++ b/caster/doc/Installation.md
@@ -21,38 +21,39 @@ Make sure to select `Add python to path`. This can be done manually by searching
 
   * [Install Video instructions](https://www.youtube.com/watch?v=dj5xgWSOEXA)
 
-### 3. Dragonfly
-* **Third** Install Dragonfly from [Command Prompt](https://www.wikihow.com/Open-the-Command-Prompt-in-Windows) or Windows Power Shell. Type `pip install dragonfly2` or `python -m pip install dragonfly2` and press enter
+### 3. Caster
 
-**Note** If migrating from [t4ngo/dragonfly](https://github.com/t4ngo/dragonfly) to [Danesprite/dragonfly](https://github.com/Danesprite/dragonfly/issues). Simply close Dragon NaturallySpeaking and run `pip uninstall dragonfly` then `pip install dragonfly2` from command line to use the danesprite's new distribution.
-
-### 4. Caster
-* **Fourth** Detailed instructions for Caster below.
+**Third** Download Caster and install dependencies.
 
 1. Download Caster from [master branch](https://github.com/synkarius/caster/archive/master.zip).
    **Note** If you plan to develop Caster use the [development branch](https://github.com/synkarius/caster/archive/develop.zip).
 2. Open up the zip file downloaded
 3. Click on the file `caster-master` or `caster-develop` .
    **Note** Choose based on your speech recognition engine.
+  * **Dragon NaturallySpeaking** (DNS) copy and paste its contents into An empty folder, this can be any folder but it is common to use `user\Documents\NatLink`.
+  * **Windows Speech Recognition**  (WSR) copy and paste its contents to a new folder. Suggested locations would be a folder on the desktop for ease of access.
+4. Check and install Caster dependencies by clicking on `Pip Install Dependencies.bat` in `\caster\bin\inno\dependencies`
+	* This can be done manually by pip installing dragonfly2, pywin32, wxpython, pillow, psutil
 
-* **Dragon NaturallySpeaking** (DNS) copy and paste its contents into `C:\NatLink\NatLink\MacroSystem` or If you installed `Natlink`  in an alternate location  `...\NatLink\MacroSystem`
-* **Windows Speech Recognition**  (WSR) copy and paste its contents to a new folder. Suggested locations would be a folder on the desktop for ease of access.
+### 4. Setup and launch
 
-1. Check and install Caster dependencies by clicking on `Pip Install Dependencies.bat` in `\caster\bin\inno\dependencies`
-	* This can be done manually by pip installing pywin32, wxpython, pillow, psutil
-2. **Final Step**. Launching Caster with a speech recognition engine.
-   ​	 **Note** Choose based on your speech recognition engine
-
-* **Dragon NaturallySpeaking** simply Launch DNS and Caster will automatically load.
+* **Dragon NaturallySpeaking**
+  1. Open the start menu and search for "natlink", click the file called "Configure NatLink via GUI" and run it using python 2.7.
+  2. Ensure that the details of your DNS setup are correct in the "info" tab.
+  3. In the "configure" tab, under "NatLink" and "UserDirectory" click enable. When you are prompted for a folder, give it the location of your caster folder from step three (`user\Documents\NatLink\caster-master`).
+  4. Reboot Dragon. NatLink should load at the same time, with caster commands available. To test this, open a notepad window and try saying "arch brov char delta".
 * **Windows Speech Recognition**  double click on `_caster.py`and it will launch WSR.
   **Note** Pending on your file associations it may launch an editor instead of running the file. Run the file using  [command prompt](https://www.wikihow.com/Open-the-Command-Prompt-in-Windows). Detailed instructions below.
-
-1. Change the directory to the to the file path you created in the step above. If the folder `<YourFile>` was named `caster-master`.
+ 1. Change the directory to the to the file path you created in the step above. If the folder `<YourFile>` was named `caster-master`.
    Example `cd C:\Users\<YourUsername>\Desktop\caster-master\`
-2. Then`python _caster.py`
+ 2. Then `python _caster.py`
 
 ### Troubleshooting FAQ
 
+* Running "Configure NatLink via GUI" does not bring up the settings window - try running the program as an administrator:
+ 1. Open an administrator command prompt by searching for "cmd" in start and either right click, run as administrator or ctrl-shift-enter.
+ 2. Change directory to the folder where start_configurenatlink.py was installed. This is likely to be `C:\NatLink\NatLink\confignatlinkvocolaunimacro` so the command would be `cd C:\NatLink\NatLink\confignatlinkvocolaunimacro`.
+ 3. Run `python start_configurenatlink.py`.
 * To fix `ImportError: No module named win32con`
   Package win32con is out of date or not installed. Try `pip install pywin32`  Alternatively if the error persists use the [Windows installer](https://sourceforge.net/projects/pywin32/files/pywin32/Build%20221/pywin32-221.win32-py2.7.exe/download)
 * To fix `lost sys.stderr`

--- a/caster/doc/Installation.md
+++ b/caster/doc/Installation.md
@@ -25,11 +25,9 @@ Make sure to select `Add python to path`. This can be done manually by searching
 
 **Third** Download Caster and install dependencies.
 
-1. Download Caster from [master branch](https://github.com/synkarius/caster/archive/master.zip).
-   **Note** If you plan to develop Caster use the [development branch](https://github.com/synkarius/caster/archive/develop.zip).
+1. Download Caster from [master branch](https://github.com/synkarius/caster/archive/master.zip). **Note** If you plan to develop Caster use the [development branch](https://github.com/synkarius/caster/archive/develop.zip).
 2. Open up the zip file downloaded
-3. Click on the file `caster-master` or `caster-develop` .
-   **Note** Choose based on your speech recognition engine.
+3. Click on the file `caster-master` or `caster-develop` . **Note** Choose based on your speech recognition engine.
   * **Dragon NaturallySpeaking** (DNS) copy and paste its contents into An empty folder, this can be any folder but it is common to use `user\Documents\NatLink`.
   * **Windows Speech Recognition**  (WSR) copy and paste its contents to a new folder. Suggested locations would be a folder on the desktop for ease of access.
 4. Check and install Caster dependencies by clicking on `Pip Install Dependencies.bat` in `\caster\bin\inno\dependencies`
@@ -42,18 +40,17 @@ Make sure to select `Add python to path`. This can be done manually by searching
   2. Ensure that the details of your DNS setup are correct in the "info" tab.
   3. In the "configure" tab, under "NatLink" and "UserDirectory" click enable. When you are prompted for a folder, give it the location of your caster folder from step three (`user\Documents\NatLink\caster-master`).
   4. Reboot Dragon. NatLink should load at the same time, with caster commands available. To test this, open a notepad window and try saying "arch brov char delta".
-* **Windows Speech Recognition**  double click on `_caster.py`and it will launch WSR.
-  **Note** Pending on your file associations it may launch an editor instead of running the file. Run the file using  [command prompt](https://www.wikihow.com/Open-the-Command-Prompt-in-Windows). Detailed instructions below.
- 1. Change the directory to the to the file path you created in the step above. If the folder `<YourFile>` was named `caster-master`.
+* **Windows Speech Recognition** double click on `_caster.py`and it will launch WSR. **Note** Depending on your file associations it may launch an editor instead of running the file. Run the file using  [command prompt](https://www.wikihow.com/Open-the-Command-Prompt-in-Windows). Detailed instructions below.
+  1. Change the directory to the to the file path you created in the step above. If the folder `<YourFile>` was named `caster-master`.
    Example `cd C:\Users\<YourUsername>\Desktop\caster-master\`
- 2. Then `python _caster.py`
+  2. Then `python _caster.py`
 
 ### Troubleshooting FAQ
 
 * Running "Configure NatLink via GUI" does not bring up the settings window - try running the program as an administrator:
- 1. Open an administrator command prompt by searching for "cmd" in start and either right click, run as administrator or ctrl-shift-enter.
- 2. Change directory to the folder where start_configurenatlink.py was installed. This is likely to be `C:\NatLink\NatLink\confignatlinkvocolaunimacro` so the command would be `cd C:\NatLink\NatLink\confignatlinkvocolaunimacro`.
- 3. Run `python start_configurenatlink.py`.
+  1. Open an administrator command prompt by searching for "cmd" in start and either right click, run as administrator or ctrl-shift-enter.
+  2. Change directory to the folder where start_configurenatlink.py was installed. This is likely to be `C:\NatLink\NatLink\confignatlinkvocolaunimacro` so the command would be `cd C:\NatLink\NatLink\confignatlinkvocolaunimacro`.
+  3. Run `python start_configurenatlink.py`.
 * To fix `ImportError: No module named win32con`
   Package win32con is out of date or not installed. Try `pip install pywin32`  Alternatively if the error persists use the [Windows installer](https://sourceforge.net/projects/pywin32/files/pywin32/Build%20221/pywin32-221.win32-py2.7.exe/download)
 * To fix `lost sys.stderr`


### PR DESCRIPTION
A couple of modifications to the installation process/instructions:

* Changed the order so that all dependencies are installed at the same time using the .bat file.
* Added instructions for modifying natlink settings using the GUI.
* Added "future" to the dependency install, this seems to be part of NatLink's move to python 3.

I'm open to suggestions for anything else which isn't clear or any more potential issues.