### PR TITLE
 A dynamically reloaded grammar file in user space.

### DIFF
--- a/caster/lib/settings.py
+++ b/caster/lib/settings.py
@@ -152,6 +152,7 @@ _DEFAULT_SETTINGS = {
 
         # CCR
         "CONFIGDEBUGTXT_PATH": BASE_PATH + "/bin/data/configdebug.txt",
+        "PLAYGROUNDTXT_PATH": BASE_PATH + "/user/playground.txt",
 
         # PYTHON
         "PYTHONW": "C:/Python27/pythonw",

--- a/caster/user/__init__.py
+++ b/caster/user/__init__.py
@@ -1,2 +1,3 @@
 from rules import *
 from filters import *
+import playgroundhelper

--- a/caster/user/playground.txt
+++ b/caster/user/playground.txt
@@ -1,0 +1,25 @@
+from dragonfly import *
+from caster.lib import navigation
+from caster.lib.dfplus.state.short import R
+
+#Unused Examples
+release = Key("shift:up, ctrl:up")
+noSpaceNoCaps = Mimic("\\no-caps-on") + Mimic("\\no-space-on") # this gets added on the right side
+
+def testfunction():
+    print ('Function: Look in the natlink window for this text')
+
+cmd.map = {
+    # Spoken-form    ->    ->    ->     Action object
+    "some command goes here": R(Pause("100"), rdescript="test command"),
+    "experiment": Function(testfunction),
+    # more...
+    }
+
+
+cmd.extras = [
+
+]
+cmd.defaults = {
+
+}

--- a/caster/user/playgroundhelper.py
+++ b/caster/user/playgroundhelper.py
@@ -1,0 +1,74 @@
+from dragonfly import (MappingRule, Config, Section, Item, Mimic, Function, Dictation, Grammar)
+
+from caster.lib import (utilities, settings)
+from caster.lib.actions import (Key, Text)
+from caster.lib.dfplus.state.short import R
+
+# Playground Grammar - Do not edit - Rebuilds playground.txt
+
+_grammar = Grammar("playground")
+
+
+class PlayGroundGen(Config):
+    def __init__(self, name):
+        Config.__init__(self, name)
+        self.cmd = Section("Language section")
+        self.cmd.map = Item(
+            {
+                "mimic <text>": Mimic(extra="text"),
+            },
+            namespace={
+                "Key": Key,
+                "Text": Text,
+            })
+        self.cmd.extras = Item([Dictation("text")])
+        self.cmd.defaults = Item({})
+
+
+def generate_rule(path):
+    configuration = PlayGroundGen("sandbox")
+    configuration.load(path)
+    return MappingRule(
+        exported=True,
+        mapping=configuration.cmd.map,
+        extras=configuration.cmd.extras,
+        defaults=configuration.cmd.defaults)
+
+
+# Create and load this module's grammar.
+def refresh():
+    global _grammar
+    _grammar.unload()
+    while len(_grammar.rules) > 0:
+        _grammar.remove_rule(_grammar.rules[0])
+    try:
+        rule = generate_rule(settings.SETTINGS["paths"]["PLAYGROUNDTXT_PATH"])
+        _grammar.add_rule(rule)
+        _grammar.load()
+        print('Playground successfully rebuilt')
+    except Exception:
+        print('Playground failed to rebuild.')
+        utilities.simple_log()
+
+grammar = Grammar('playground helper')
+
+# Playground Helper Grammar
+
+def run_remote_debugger():
+    utilities.remote_debug("playgroundhelper.py")
+
+
+class PlaygroundHelpers(MappingRule):
+    mapping = {
+
+        "rebuild playground": # Rebuilds grammars for this file.
+            R(Function(refresh, rdescript="Playground: Rebuilding PlayGround Grammars...")),
+        "run remote debugger": # You will need to set up a remote debugger for your editor.
+            R(Function(run_remote_debugger, rdescript="Playground: Initializing debugger...")),
+    }
+
+def load():
+    global grammar
+    grammar.add_rule(PlaygroundHelpers())
+    grammar.load()
+load()


### PR DESCRIPTION
I get the impression that many people experiment within the source code of Caster. This is going to be an issue when Castor becomes a package or currently during updates. 

Primary goals
- Keep it simple - We don't want to overwhelm newcomers.
- Provide a safe area for users to experiment with commands and functions without having to reboot Dragon. 
- Include functional examples demonstrating a variety of implementation.

Currently it works as advertised but is still a work in progress. I would like feedback and community in regard to what examples to include. This is be active by default but in the future it will include a welcome message guiding the user to utilizing the file.

Current thoughts for a name is playground but that's up for debate. This is based off the trim down version of Dev and Devgen. 

The `configdebug.txt` which is utilized by Dev and Devgen contain syntax errors.
I've effectively combined and simplified `Dev `and `Devgen ` in playgroundhelper.py and put a new file called `playground.txt` located in the user directory `caster\user\playground.txt` playground.txt generates a ccr global a grammar.

**Getting Started**
Make your edits to `playground.txt` then say the `rebuild playground` command. If there is an error it will print out in the natlink window. Simply rerun the command as needed.
I've not had a chance to test  `run remote debugger` command.

