### PR TITLE
UI path finding bug fix

### DIFF
--- a/caster/asynch/hmc/h_launch.py
+++ b/caster/asynch/hmc/h_launch.py
@@ -2,7 +2,7 @@ from subprocess import Popen
 import sys, os
 
 try:  # Style C -- may be imported into Caster, or externally
-    BASE_PATH = os.path.realpath(__file__).split("\\caster")[0].replace("\\", "/")
+    BASE_PATH = os.path.realpath(__file__).rsplit(os.path.sep + "caster", 1)[0]
     if BASE_PATH not in sys.path:
         sys.path.append(BASE_PATH)
 finally:

--- a/caster/asynch/hmc/hmc_ask_directory.py
+++ b/caster/asynch/hmc/hmc_ask_directory.py
@@ -5,7 +5,7 @@ from threading import Timer
 import tkFileDialog
 
 try:  # Style C -- may be imported into Caster, or externally
-    BASE_PATH = os.path.realpath(__file__).split("\\caster")[0].replace("\\", "/")
+    BASE_PATH = os.path.realpath(__file__).rsplit(os.path.sep + "caster", 1)[0]
     if BASE_PATH not in sys.path:
         sys.path.append(BASE_PATH)
 finally:

--- a/caster/asynch/hmc/hmc_confirm.py
+++ b/caster/asynch/hmc/hmc_confirm.py
@@ -4,7 +4,7 @@ import sys
 from threading import Timer
 
 try:  # Style C -- may be imported into Caster, or externally
-    BASE_PATH = os.path.realpath(__file__).split("\\caster")[0].replace("\\", "/")
+    BASE_PATH = os.path.realpath(__file__).rsplit(os.path.sep + "caster", 1)[0]
     if BASE_PATH not in sys.path:
         sys.path.append(BASE_PATH)
 finally:

--- a/caster/asynch/hmc/hmc_recording.py
+++ b/caster/asynch/hmc/hmc_recording.py
@@ -5,7 +5,7 @@ from threading import Timer
 import Tkinter as tk
 
 try:  # Style C -- may be imported into Caster, or externally
-    BASE_PATH = os.path.realpath(__file__).split("\\caster")[0].replace("\\", "/")
+    BASE_PATH = os.path.realpath(__file__).rsplit(os.path.sep + "caster", 1)[0]
     if BASE_PATH not in sys.path:
         sys.path.append(BASE_PATH)
 finally:

--- a/caster/asynch/hmc/homunculus.py
+++ b/caster/asynch/hmc/homunculus.py
@@ -7,7 +7,7 @@ from threading import Timer
 import Tkinter as tk
 
 try:  # Style C -- may be imported into Caster, or externally
-    BASE_PATH = os.path.realpath(__file__).split("\\caster")[0].replace("\\", "/")
+    BASE_PATH = os.path.realpath(__file__).rsplit(os.path.sep + "caster", 1)[0]
     if BASE_PATH not in sys.path:
         sys.path.append(BASE_PATH)
 finally:

--- a/caster/asynch/mouse/grids.py
+++ b/caster/asynch/mouse/grids.py
@@ -15,7 +15,7 @@ import Tkinter as tk
 from dragonfly import monitors
 
 try:  # Style C -- may be imported into Caster, or externally
-    BASE_PATH = os.path.realpath(__file__).split("\\caster")[0].replace("\\", "/")
+    BASE_PATH = os.path.realpath(__file__).rsplit(os.path.sep + "caster", 1)[0]
     if BASE_PATH not in sys.path:
         sys.path.append(BASE_PATH)
 finally:

--- a/caster/asynch/mouse/legion.py
+++ b/caster/asynch/mouse/legion.py
@@ -9,7 +9,7 @@ from dragonfly import monitors
 #from dragonfly import monitors
 
 try:  # Style C -- may be imported into Caster, or externally
-    BASE_PATH = os.path.realpath(__file__).split("\\caster")[0].replace("\\", "/")
+    BASE_PATH = os.path.realpath(__file__).rsplit(os.path.sep + "caster", 1)[0]
     if BASE_PATH not in sys.path:
         sys.path.append(BASE_PATH)
 finally:

--- a/caster/asynch/settingswindow.py
+++ b/caster/asynch/settingswindow.py
@@ -12,7 +12,7 @@ from wx import Notebook, NB_MULTILINE, Menu, ID_EXIT, EVT_MENU, MenuBar, \
 from wx.lib.scrolledpanel import ScrolledPanel
 
 try:  # Style C -- may be imported into Caster, or externally
-    BASE_PATH = os.path.realpath(__file__).split("\\caster")[0]
+    BASE_PATH = os.path.realpath(__file__).rsplit(os.path.sep + "caster", 1)[0]
     if BASE_PATH not in sys.path:
         sys.path.append(BASE_PATH)
 finally:

--- a/caster/asynch/settingswindow.py
+++ b/caster/asynch/settingswindow.py
@@ -12,7 +12,7 @@ from wx import Notebook, NB_MULTILINE, Menu, ID_EXIT, EVT_MENU, MenuBar, \
 from wx.lib.scrolledpanel import ScrolledPanel
 
 try:  # Style C -- may be imported into Caster, or externally
-    BASE_PATH = os.path.realpath(__file__).split("\\caster")[0].replace("\\", "/")
+    BASE_PATH = os.path.realpath(__file__).split("\\caster")[0]
     if BASE_PATH not in sys.path:
         sys.path.append(BASE_PATH)
 finally:

--- a/caster/lib/settings.py
+++ b/caster/lib/settings.py
@@ -10,7 +10,7 @@ import _winreg
 
 SETTINGS = {}
 _SETTINGS_PATH = os.path.realpath(__file__).split("lib")[0] + "bin\\data\\settings.toml"
-BASE_PATH = os.path.realpath(__file__).split("\\lib")[0].replace("\\", "/")
+BASE_PATH = os.path.realpath(__file__).split("\\lib")[0]
 
 # title
 SOFTWARE_VERSION_NUMBER = "0.5.11"

--- a/caster/lib/settings.py
+++ b/caster/lib/settings.py
@@ -9,8 +9,8 @@ import errno
 import _winreg
 
 SETTINGS = {}
-_SETTINGS_PATH = os.path.realpath(__file__).split("lib")[0] + "bin\\data\\settings.toml"
-BASE_PATH = os.path.realpath(__file__).split("\\lib")[0]
+BASE_PATH = os.path.realpath(__file__).rsplit(os.path.sep + "lib", 1)[0].replace("\\", "/")
+_SETTINGS_PATH = BASE_PATH + "/bin/data/settings.toml"
 
 # title
 SOFTWARE_VERSION_NUMBER = "0.5.11"

--- a/caster/lib/utilities.py
+++ b/caster/lib/utilities.py
@@ -20,7 +20,7 @@ from _winreg import (CloseKey, ConnectRegistry, HKEY_CLASSES_ROOT,
 from dragonfly.windows.window import Window
 
 try:  # Style C -- may be imported into Caster, or externally
-    BASE_PATH = os.path.realpath(__file__).split("\\caster")[0].replace("\\", "/")
+    BASE_PATH = os.path.realpath(__file__).rsplit(os.path.sep + "caster", 1)[0]
     if BASE_PATH not in sys.path:
         sys.path.append(BASE_PATH)
 finally:


### PR DESCRIPTION
Fixes a bug whereby UI windows don't launch if any of the folders in the directory tree begin with "caster". 