### PR TITLE
Seeking clarification on MergeRule type.

### DIFF
--- a/castervoice/lib/ctrl/mgr/rule_maker/mapping_rule_maker.py
+++ b/castervoice/lib/ctrl/mgr/rule_maker/mapping_rule_maker.py
@@ -1,5 +1,6 @@
 from dragonfly import Grammar, AppContext
 from castervoice.lib.ctrl.mgr.rule_maker.base_rule_maker import BaseRuleMaker
+from castervoice.lib.merge.mergerule import MergeRule
 
 
 class MappingRuleMaker(BaseRuleMaker):
@@ -20,6 +21,8 @@ class MappingRuleMaker(BaseRuleMaker):
             rule_instance = self._transformers_runner.transform_rule(rule_instance)
 
         self._smr_configurer.configure(rule_instance)
+        if isinstance(rule_instance, MergeRule):
+            rule_instance = rule_instance.to_mapping_rule()
 
         context = None
         if details.executable is not None or details.title is not None:


### PR DESCRIPTION
Does this implement the behavior you were intending?
Caster crashes at startup in `MappingRuleMaker.create_non_ccr_grammar()` while processing `HMCLaunchRule` without this change because `MergeRule` no longer inherits from `MappingRule` and therefore `grammar.add_rule(rule_instance)`  throws an exception.