### PR TITLE
Fix questionable syntax in ide.py

### DIFF
--- a/castervoice/apps/ide/ide_shared.py
+++ b/castervoice/apps/ide/ide_shared.py
@@ -4,6 +4,7 @@
 from castervoice.apps.shared.directions import FORWARD, RIGHT, BACK, LEFT, UP, DOWN
 
 method = "(meth|method)"
+methods = "(meths|methods)"
 
 # general
 EXPAND_SELECTION = "expand [selection] [<n>]"
@@ -87,6 +88,6 @@ EXTRACT_VARIABLE = "%s [variable|var]" % extract
 EXTRACT_FIELD = "%s field" % extract
 EXTRACT_CONSTANT = "%s constant" % extract
 EXTRACT_PARAMETER = "%s (param|parameter)" % extract
-IMPLEMENT_METHODS = "implement (%s|%ss)" % (method, method)
+IMPLEMENT_METHODS = "implement (%s|%s)" % (method, methods)
 OVERRIDE_METHOD = "override %s" % method
 AUTO_INDENT = "auto indent"


### PR DESCRIPTION
I am in the process of [replacing the dragonfly parser](https://github.com/dictation-toolbox/dragonfly/pull/154). As far as I can tell everything in caster parses correctly except for this section, which expands to:
```
"((meth|method)|(meth|method)s)"
```

I don't really think this should be valid syntax, and it would require quite an ugly special case to handle. Since it is only one instance I think it's easier just to fix it in place. It may also be worth applying the same patch to the main repo to minimize the chances of users getting an error message when they update dragonfly.