### PR TITLE
Updated Manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,9 +5,13 @@ include docs/README.md
 include castervoice/bin/data/configdebug.txt
 include castervoice/bin/share/words.txt
 include castervoice/bin/share/git_repo_local_to_remote_match.toml.defaults
-include castervoice/bin/VirtualDesktopAccessor.dll
+include castervoice/bin/VirtualDesktopAccessor32.dll
+include castervoice/bin/VirtualDesktopAccessor64.dll
 include castervoice/bin/reboot.bat
 include castervoice/bin/reboot_wsr.bat
 include castervoice/lib/dll/tirg-dll.dll
 include castervoice/asynch/sikuli/server/xmlrpc_server.sikuli/xmlrpc_server.html
 include castervoice/asynch/sikuli/server/xmlrpc_server.sikuli/xmlrpc_server.py
+include castervoice/lib/github_automation.ahk
+include requirements.txt
+include requirements-dev.txt


### PR DESCRIPTION
Adds 
VirtualDesktopAccessor 64 and 32bit
requirements.txt # Necessary for parsing missing dependencies
requirements-dev.txt # Necessary for unit tests
github_automation.ahk